### PR TITLE
feat: password recovery via email (FastAPI Mail, config, and HTML template)

### DIFF
--- a/backend/app/controllers/auth_controller.py
+++ b/backend/app/controllers/auth_controller.py
@@ -6,6 +6,8 @@ from app.core.security import create_access_token
 from app.repository.user_repository import UserRepository
 from app.core.config import settings
 from jose import jwt, JWTError
+from app.core.mail import config
+from fastapi_mail import FastMail, MessageSchema
 
 class AuthController:
     """
@@ -135,4 +137,26 @@ class AuthController:
         return {
             "success": success,
             "message": message
+        }
+    
+    @staticmethod
+    async def recover_user_password(email: str):
+        user = UserRepository.find_by_email(email)
+
+        if not user:
+            raise HTTPException(status_code=400, detail="Correo inválido")
+        
+        message = MessageSchema(
+            subject="Recuperación de contraseña",
+            recipients=[email],
+            template_body={"name": user["user_name"]},
+            subtype="html",
+        )
+        
+        fm = FastMail(config)
+        await fm.send_message(message, template_name="recover_password.html")
+
+        return {
+            "success": True,
+            "messagge": "Correo enviado correctamente"
         }

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -1,4 +1,5 @@
 from pydantic_settings import BaseSettings
+from pydantic import EmailStr
 
 class Settings(BaseSettings):
     """
@@ -19,6 +20,9 @@ class Settings(BaseSettings):
     SECRET_KEY: str
     ALGORITHM: str
     ACCESS_TOKEN_EXPIRE: int
+    MAIL_USERNAME: EmailStr
+    MAIL_PASSWORD: str
+    MAIL_FROM: EmailStr
 
     class Config:
         env_file = ".env"

--- a/backend/app/core/mail.py
+++ b/backend/app/core/mail.py
@@ -1,0 +1,14 @@
+from fastapi_mail import ConnectionConfig
+from app.core.config import settings
+from pathlib import Path
+
+config = ConnectionConfig(
+    MAIL_USERNAME=settings.MAIL_USERNAME,
+    MAIL_PASSWORD=settings.MAIL_PASSWORD,
+    MAIL_FROM=settings.MAIL_FROM,
+    MAIL_PORT=587,
+    MAIL_SERVER="smtp.gmail.com",
+    MAIL_STARTTLS=True,
+    MAIL_SSL_TLS=False,
+    TEMPLATE_FOLDER=Path(__file__).parent.parent / "templates",
+)

--- a/backend/app/models/auth_model.py
+++ b/backend/app/models/auth_model.py
@@ -3,3 +3,6 @@ from pydantic import BaseModel, EmailStr
 class LoginModel(BaseModel):
     email: EmailStr
     password: str
+
+class RecoverPassword(BaseModel):
+    email: EmailStr

--- a/backend/app/routes/auth_routes.py
+++ b/backend/app/routes/auth_routes.py
@@ -1,8 +1,9 @@
 from fastapi import APIRouter, Depends, Response, Cookie, Body
 from app.controllers.auth_controller import AuthController
-from app.models.auth_model import LoginModel
+from app.models.auth_model import LoginModel, RecoverPassword
 from app.models.user_model import UpdateUser, UpdatePassword
 from app.middlewares.jwt_middleware import verify_jwt
+from pydantic import EmailStr
 
 router = APIRouter(
     prefix="/api/auth", 
@@ -34,6 +35,12 @@ def get_me(access_token: str = Cookie(None)):
 def update_me(user_data: UpdateUser = Body(...), payload: dict = Depends(verify_jwt)):
     return AuthController.update_current_user(user_data, payload)
 
+# Endpoint para actulizar la contraseña del usuario
 @router.put("/update-password")
 def update_user_password(password_data: UpdatePassword, payload: dict = Depends(verify_jwt)):
     return AuthController.update_user_password(password_data, payload)
+
+# Endpoint para recuperar contraseña
+@router.post("/recover-password")
+async def recover_user_password(data: RecoverPassword):
+    return await AuthController.recover_user_password(data.email)

--- a/backend/app/templates/recover_password.html
+++ b/backend/app/templates/recover_password.html
@@ -1,0 +1,51 @@
+<!doctype html>
+<html>
+  <body
+    style="
+      font-family:
+        DM Sans,
+        sans-serif !important;
+      padding: 20px;
+    "
+  >
+    <div
+      style="
+        max-width: 500px;
+        margin: auto;
+        background: white;
+        padding: 30px;
+        border-radius: 12px;
+      "
+    >
+      <h1 style="text-align: center">Hola, {{ name }} 👋</h1>
+      <p style="text-align: center; font-size: large">
+        Recibimos una solicitud para restablecer tu contraseña.
+      </p>
+      <div style="padding-left: 20%; margin-bottom: 35px; margin-top: 35px">
+        <a
+          href="127.0.0.1:5173"
+          style="
+          cursor: pointer;
+            margin-top: 15px;
+            font-weight: 700;
+            font-size: 20px;
+            background: black;
+            color: white;
+            padding: 15px 28px;
+            border-radius: 25px;
+            text-decoration: none;
+          "
+        >
+          Restablecer contraseña
+        </a>
+      </div>
+      <p style="text-align: center; color: #666; font-size: 12px">
+        Si no solicitaste esto, ignora este correo.
+      </p>
+      <p style="text-align: center; color: #666; font-size: 12px">
+        Este es un correo automático,<br />
+        Por favor, no respondas a este mensaje.
+      </p>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
## Summary

Adds **password recovery** backed by **email**: app settings for mail, FastAPI Mail wiring, a **RecoverPassword** model, auth routes and controller logic for recovery and password update, and an **HTML email template** for the reset flow. Backend-only; no frontend changes in this PR.

## Changes

- **Configuration**: `config.py` — email-related settings for notifications; `mail.py` — FastAPI Mail setup for sending messages.
- **Models**: `auth_model.py` — `RecoverPassword` (and related fields) for the recovery payload.
- **API**: `auth_controller.py` / `auth_routes.py` — endpoints for **password recovery** and **updating password** after recovery.
- **Templates**: `templates/recover_password.html` — HTML body for the recovery email.

<img width="1592" height="509" alt="Captura de pantalla 2026-04-03 154609" src="https://github.com/user-attachments/assets/418170da-5802-4b93-be47-ead948484984" />