### PR TITLE
feat: add access token validation in JWT middleware to handle missing…

### DIFF
--- a/backend/app/middlewares/jwt_middleware.py
+++ b/backend/app/middlewares/jwt_middleware.py
@@ -10,6 +10,9 @@ async def verify_jwt(access_token: str = Cookie(None)):
         detail="Token inválido o expirado",
     )
 
+    if not access_token:
+        raise credentials_exception
+
     try:
         token = access_token.replace("Bearer ", "")
         payload = jwt.decode(
@@ -24,11 +27,10 @@ async def verify_jwt(access_token: str = Cookie(None)):
         if not user_id or not role:
             raise credentials_exception
 
-    except JWTError as e:
-        print("error", {e})
+    except JWTError:
         raise credentials_exception
-    
-    return{
+
+    return {
         "user_id": user_id,
         "role": role
     }


### PR DESCRIPTION
## Summary

Tightens **JWT middleware** behavior by validating the **access token** and handling the **missing-token** case explicitly, so protected routes fail in a predictable way instead of relying on implicit failures later in the pipeline.

## Changes

- **`jwt_middleware.py`**: add **access token validation** and clearer handling when the token is absent