### PR TITLE
refactor: use UpdateCurrentUser model for auth current-user updates

### DIFF
--- a/backend/app/controllers/auth_controller.py
+++ b/backend/app/controllers/auth_controller.py
@@ -1,6 +1,6 @@
 from fastapi import HTTPException, Response, Cookie
 from datetime import timedelta
-from app.models.user_model import UpdateUser, UpdatePassword
+from app.models.user_model import UpdateCurrentUser, UpdatePassword
 from app.core.security import verify_password
 from app.core.security import create_access_token
 from app.repository.user_repository import UserRepository
@@ -109,8 +109,8 @@ class AuthController:
             raise HTTPException(status_code=401, detail="Token inválido")
 
     @staticmethod
-    def update_current_user(user_data: UpdateUser, payload: dict):
-        error, success, message = UserRepository.update(
+    def update_current_user(user_data: UpdateCurrentUser, payload: dict):
+        error, success, message = UserRepository.update_current_user(
             int(payload["user_id"]), user_data)
 
         if error:

--- a/backend/app/models/user_model.py
+++ b/backend/app/models/user_model.py
@@ -24,6 +24,15 @@ class UpdateUser(BaseModel):
     phone: int
     status: int
 
+class UpdateCurrentUser(BaseModel):
+    name: str
+    first_surname: str
+    second_surname: str
+    address: str
+    city: str
+    email: EmailStr
+    phone: int
+
 class UpdatePassword(BaseModel):
     old_password: str
     new_password: str

--- a/backend/app/repository/user_repository.py
+++ b/backend/app/repository/user_repository.py
@@ -1,6 +1,5 @@
 from app.core.database import get_connection
-from app.models.user_model import User, UpdateUser, UpdatePassword
-from datetime import datetime
+from app.models.user_model import User, UpdateUser, UpdateCurrentUser
 from app.utils.date_formatter import date_formatter
 import bcrypt
 
@@ -252,6 +251,66 @@ class UserRepository:
         except Exception as e:
             connection.rollback()
             return f"Error al ejecutar la consulta: {e}", False, None
+        finally:
+            cursor.close()
+            connection.close()
+
+
+    # Actualizar la información de un usuario
+    @staticmethod
+    def update_current_user(user_id: int, user_data: UpdateCurrentUser):
+        data = user_data.model_dump()
+
+        connection = get_connection()
+        cursor = connection.cursor(dictionary=True)
+
+        # Verificar si existe el usuario
+        cursor.execute("SELECT * FROM USERS WHERE user_id = %s", (user_id,))
+        user = cursor.fetchone()
+
+        if not user:
+            cursor.close()
+            connection.close()
+            return "Usuario no encontrado", None, None
+            
+        # Verificar si existe el correo y no duplicarlo
+        if "user_email" in user_data:
+            cursor.execute("SELECT user_id FROM USERS WHERE user_email = %s", (user_data["user_email"],))
+            existing = cursor.fetchone()
+            
+            if existing and existing["user_id"] != user_id:
+                cursor.close()
+                connection.close()
+                return None, False, "El correo ya está registrado"
+
+        query = """
+        UPDATE USERS SET
+            user_name = %s,
+            user_first_surname = %s,
+            user_second_surname = %s,
+            user_email = %s,
+            user_phone = %s,
+            user_city = %s,
+            user_address = %s
+        WHERE user_id = %s"""
+
+        try:
+            cursor.execute(query, (
+                data["name"], 
+                data["first_surname"], 
+                data["second_surname"], 
+                data["email"], 
+                data["phone"],
+                data["address"], 
+                data["city"],
+                user_id 
+            ))
+            connection.commit()
+
+            return None, True, "Usuario actualizado correctamente"
+        except Exception as e:
+            connection.rollback()
+            return f"Error al ejecutar la consulta", False, None
         finally:
             cursor.close()
             connection.close()

--- a/backend/app/routes/auth_routes.py
+++ b/backend/app/routes/auth_routes.py
@@ -1,7 +1,7 @@
 from fastapi import APIRouter, Depends, Response, Cookie, Body
 from app.controllers.auth_controller import AuthController
 from app.models.auth_model import LoginModel, RecoverPassword
-from app.models.user_model import UpdateUser, UpdatePassword
+from app.models.user_model import UpdateCurrentUser, UpdatePassword
 from app.middlewares.jwt_middleware import verify_jwt
 
 router = APIRouter(
@@ -31,7 +31,7 @@ def get_me(access_token: str = Cookie(None)):
 
 #Endpoint para actualizar la informacion del usuario
 @router.put("/update/me")
-def update_me(user_data: UpdateUser = Body(...), payload: dict = Depends(verify_jwt)):
+def update_me(user_data: UpdateCurrentUser = Body(...), payload: dict = Depends(verify_jwt)):
     return AuthController.update_current_user(user_data, payload)
 
 # Endpoint para actulizar la contraseña del usuario


### PR DESCRIPTION
## Summary

Adds backend support to **update the currently authenticated user** from auth endpoints, introducing an `UpdateCurrentUser` model and repository/controller flow with **email validation** for safer profile changes. Refactors auth route typing/imports to use the new model consistently. Backend-only.

## Changes

- **Models**: `user_model.py` — add `UpdateCurrentUser` for current-user update payloads.
- **Repository**: `user_repository.py` — add/update method(s) for current-user updates with validation logic (including email checks).
- **Controller**: `auth_controller.py` — implement `update_current_user` handling for authenticated profile updates.
- **Routes**: `auth_routes.py` — switch request model usage/imports to `UpdateCurrentUser` for consistent auth update contracts.