### PR TITLE
feat: unify report pages, add export/KPI shell, and period-driven product/user charts

### DIFF
--- a/frontend_web/react+vite/src/modules/reports/ReportsPage.jsx
+++ b/frontend_web/react+vite/src/modules/reports/ReportsPage.jsx
@@ -45,47 +45,16 @@ export default function ReportsPage() {
         />
       )}
       {/* Contenido principal dinamico */}
-      {report === "users" && (
-        <UsersReport
-          setReport={setReport}
-          setTopSectionVisiblity={setTopSectionVisiblity}
-        />
-      )}
-      {report === "products" && (
-        <ProductsReport
-          setReport={setReport}
-          setTopSectionVisiblity={setTopSectionVisiblity}
-        />
-      )}
-      {report === "categories" && (
-        <CategoriesReport
-          setReport={setReport}
-          setTopSectionVisiblity={setTopSectionVisiblity}
-        />
-      )}
+      {report === "users" && <UsersReport setReport={setReport} />}
+      {report === "products" && <ProductsReport setReport={setReport} />}
+      {report === "categories" && <CategoriesReport setReport={setReport} />}
       {report === "subcategories" && (
-        <SubcategoriesReport
-          setReport={setReport}
-          setTopSectionVisiblity={setTopSectionVisiblity}
-        />
+        <SubcategoriesReport setReport={setReport} />
       )}
-      {report === "warranties" && (
-        <WarrantiesReport
-          setReport={setReport}
-          setTopSectionVisiblity={setTopSectionVisiblity}
-        />
-      )}
-      {report === "suppliers" && (
-        <SuppliersReport
-          setReport={setReport}
-          setTopSectionVisiblity={setTopSectionVisiblity}
-        />
-      )}
+      {report === "warranties" && <WarrantiesReport setReport={setReport} />}
+      {report === "suppliers" && <SuppliersReport setReport={setReport} />}
       {report === "transformations" && (
-        <TransformationsReport
-          setReport={setReport}
-          setTopSectionVisiblity={setTopSectionVisiblity}
-        />
+        <TransformationsReport setReport={setReport} />
       )}
 
       {/* Modales */}

--- a/frontend_web/react+vite/src/modules/reports/components/ui/ExportButton.jsx
+++ b/frontend_web/react+vite/src/modules/reports/components/ui/ExportButton.jsx
@@ -1,0 +1,18 @@
+import { actionsIcons } from "../../../../assets/icons/mainIcons";
+
+export default function ExportButton() {
+  return (
+    <button
+      className="flex items-center px-4 py-2 gap-2 border rounded-xl shadow-md text-sm transition-all duration-300
+      hover:bg-gray-200
+      dark:text-white dark:border-[#9490902d] dark:hover:bg-[#2c2c2e]"
+    >
+      <img
+        src={actionsIcons.uploadIcon}
+        alt=""
+        className="w-5 h-5 dark:invert"
+      />
+      <span>Exportar</span>
+    </button>
+  );
+}

--- a/frontend_web/react+vite/src/modules/reports/components/ui/KpiCard.jsx
+++ b/frontend_web/react+vite/src/modules/reports/components/ui/KpiCard.jsx
@@ -1,15 +1,14 @@
-export default function KpiCard({ name, metricValue, percentValue }) {
+export default function KpiCard({ name, metricValue }) {
   return (
     <section
-      className="flex flex-col pt-2 pl-4 row-span-1 col-span-3 bg-[#eff6ff81]
-        shadow-md border border-gray-200 rounded-xl transition duration-500
+      key={name}
+      className="flex flex-col pt-5 pl-4 row-span-1 col-span-1 bg-[#9b9ea315] shadow-md border border-gray-200 rounded-xl transition duration-500
         hover:bg-gray-200 hover:scale-[1.02]
         dark:bg-[#0f0f11] dark:border-transparent dark:shadow-[0px_0px_10px_2px_#0f0f11] dark:hover:bg-[#2c2c2e] dark:text-white"
     >
       <section className="flex flex-col items-start justify-between">
         <span className="text-sm"> {name} </span>
         <span className="pt-1 text-5xl font-medium">{metricValue}</span>
-        <span>{percentValue}</span>
       </section>
     </section>
   );

--- a/frontend_web/react+vite/src/modules/reports/components/ui/KpisContainer.jsx
+++ b/frontend_web/react+vite/src/modules/reports/components/ui/KpisContainer.jsx
@@ -1,0 +1,21 @@
+import KpiCard from "./KpiCard";
+
+export default function KpisContainer({
+  firstKpiName,
+  firstKpiValue,
+  secondKpiName,
+  secondKpiValue,
+  thirdKpiName,
+  thirdKpiValue,
+  fourthKpiName,
+  fourthKpiValue,
+}) {
+  return (
+    <section className="col-span-12 row-span-1 grid grid-cols-4 grid-rows-1 gap-3">
+      <KpiCard name={firstKpiName} metricValue={firstKpiValue} />
+      <KpiCard name={secondKpiName} metricValue={secondKpiValue} />
+      <KpiCard name={thirdKpiName} metricValue={thirdKpiValue} />
+      <KpiCard name={fourthKpiName} metricValue={fourthKpiValue} />
+    </section>
+  );
+}

--- a/frontend_web/react+vite/src/modules/reports/components/ui/ReportCard.jsx
+++ b/frontend_web/react+vite/src/modules/reports/components/ui/ReportCard.jsx
@@ -1,10 +1,7 @@
-export default function ReportCard({
-  name,
-  colSpan,
-  children
-}) {
+export default function ReportCard({ name, colSpan, children }) {
   return (
     <section
+      key={name}
       className={`row-span-3 col-span-${colSpan} bg-white dark:text-white
         flex flex-col p-5 shadow-md border border-gray-200 rounded-xl transition duration-500
         hover:bg-gray-200 hover:scale-[1.01]
@@ -12,9 +9,7 @@ export default function ReportCard({
     >
       <section className="flex flex-col items-start justify-between gap-6">
         <span> {name} </span>
-        <section className="h-auto w-full">
-          {children}
-        </section>
+        <section className="h-auto w-full">{children}</section>
       </section>
     </section>
   );

--- a/frontend_web/react+vite/src/modules/reports/components/ui/ReportsContainer.jsx
+++ b/frontend_web/react+vite/src/modules/reports/components/ui/ReportsContainer.jsx
@@ -1,0 +1,19 @@
+export default function ReportsContainer({
+  reportsName,
+  reportsDate,
+  children,
+}) {
+  return (
+    <section
+      className="h-full w-full grid p-3 pt-2
+        xl:grid-cols-[repeat(16,_1fr)] xl:grid-rows-7
+        gap-3"
+    >
+      <section className="col-span-4 row-span-1 flex flex-col justify-center items-start dark:text-white">
+        <span className="text-2xl font-medium">Reporte de {reportsName}</span>
+        <span className="text-sm">{reportsDate}</span>
+      </section>
+      {children}
+    </section>
+  );
+}

--- a/frontend_web/react+vite/src/modules/reports/components/ui/ReportsTopSection.jsx
+++ b/frontend_web/react+vite/src/modules/reports/components/ui/ReportsTopSection.jsx
@@ -3,43 +3,32 @@ import ExportButton from "./ExportButton";
 
 export default function ReportsTopSection({
   setReport,
-  sevenDaysOnclick,
-  thirtyDaysOnclick,
-  sixMonthsOnClick,
-  oneYearOnClick,
+  setPeriod,
+  periods,
+  currentPeriod,
 }) {
   return (
     <section className="flex items-center justify-between pl-3 dark:text-white">
       <ReturnButton onClick={() => setReport("home")} />
       <div className="flex items-center justify-end gap-1.5 pr-3">
         <div
-          className="flex gap-1 py-0.5 px-1 border rounded-xl text-sm font-medium bg-gray-200 
-                  dark:bg-gray-950 dark:border-neutral-800 "
+          className="flex gap-1 py-0.5 px-1 border rounded-xl text-sm font-medium bg-gray-200
+          dark:bg-gray-950 dark:border-neutral-800"
         >
-          <button
-            onClick={sevenDaysOnclick}
-            className="px-4 py-1.5 rounded-lg hover:bg-gray-300 transition duration-300"
-          >
-            7d
-          </button>
-          <button
-            onClick={thirtyDaysOnclick}
-            className="px-4 py-1.5 rounded-xl bg-white shadow-md dark:text-black"
-          >
-            30d
-          </button>
-          <button
-            onClick={sixMonthsOnClick}
-            className="px-4 py-1.5 rounded-lg hover:bg-gray-300 transition duration-300"
-          >
-            6m
-          </button>
-          <button
-            onClick={oneYearOnClick}
-            className="px-4 py-1.5 rounded-lg hover:bg-gray-300 transition duration-300"
-          >
-            1a
-          </button>
+          {periods.map((period) => (
+            <button
+              key={period}
+              onClick={() => setPeriod(period)}
+              className={`px-4 py-1.5 rounded-lg 
+              ${
+                currentPeriod === period
+                  ? "bg-white shadow-md dark:text-black"
+                  : "hover:bg-gray-300 transition duration-300 dark:hover:bg-[#2c2c2e]"
+              }`}
+            >
+              {period}
+            </button>
+          ))}
         </div>
         <ExportButton />
       </div>

--- a/frontend_web/react+vite/src/modules/reports/components/ui/ReportsTopSection.jsx
+++ b/frontend_web/react+vite/src/modules/reports/components/ui/ReportsTopSection.jsx
@@ -1,0 +1,48 @@
+import ReturnButton from "./ReturnButton";
+import ExportButton from "./ExportButton";
+
+export default function ReportsTopSection({
+  setReport,
+  sevenDaysOnclick,
+  thirtyDaysOnclick,
+  sixMonthsOnClick,
+  oneYearOnClick,
+}) {
+  return (
+    <section className="flex items-center justify-between pl-3 dark:text-white">
+      <ReturnButton onClick={() => setReport("home")} />
+      <div className="flex items-center justify-end gap-1.5 pr-3">
+        <div
+          className="flex gap-1 py-0.5 px-1 border rounded-xl text-sm font-medium bg-gray-200 
+                  dark:bg-gray-950 dark:border-neutral-800 "
+        >
+          <button
+            onClick={sevenDaysOnclick}
+            className="px-4 py-1.5 rounded-lg hover:bg-gray-300 transition duration-300"
+          >
+            7d
+          </button>
+          <button
+            onClick={thirtyDaysOnclick}
+            className="px-4 py-1.5 rounded-xl bg-white shadow-md dark:text-black"
+          >
+            30d
+          </button>
+          <button
+            onClick={sixMonthsOnClick}
+            className="px-4 py-1.5 rounded-lg hover:bg-gray-300 transition duration-300"
+          >
+            6m
+          </button>
+          <button
+            onClick={oneYearOnClick}
+            className="px-4 py-1.5 rounded-lg hover:bg-gray-300 transition duration-300"
+          >
+            1a
+          </button>
+        </div>
+        <ExportButton />
+      </div>
+    </section>
+  );
+}

--- a/frontend_web/react+vite/src/modules/reports/components/ui/ReturnButton.jsx
+++ b/frontend_web/react+vite/src/modules/reports/components/ui/ReturnButton.jsx
@@ -3,8 +3,9 @@ import { actionsIcons } from "../../../../assets/icons/mainIcons";
 export default function ReturnButton({ onClick }) {
   return (
     <button
-      className="flex items-center gap-1 px-3.5 py-1.5 border rounded-md shadow-md
-      dark:text-white dark:border-[#9490902d]"
+      className="flex items-center gap-1 px-3.5 py-1.5 border rounded-md shadow-md transition-all duration-300
+      hover:bg-gray-200
+      dark:text-white dark:border-[#9490902d] dark:hover:bg-[#2c2c2e]"
       onClick={onClick}
     >
       <img

--- a/frontend_web/react+vite/src/modules/reports/components/ui/SectionsContainer.jsx
+++ b/frontend_web/react+vite/src/modules/reports/components/ui/SectionsContainer.jsx
@@ -25,7 +25,10 @@ export default function SectionsContainer({
     >
       {sections.map((section) => (
         <ReportSectionCard
-          sectionOnClick={() => setReport(`${section.name}`)}
+          sectionOnClick={() => {
+            setReport(`${section.name}`);
+            setTopSectionVisiblity(false);
+          }}
           sectionKey={section.name}
           sectionIcon={section.icon}
           sectionIconAlt={section.alt}

--- a/frontend_web/react+vite/src/modules/reports/components/ui/TableCard.jsx
+++ b/frontend_web/react+vite/src/modules/reports/components/ui/TableCard.jsx
@@ -1,6 +1,7 @@
 export default function TableCard({ tableTitle, children }) {
   return (
     <section
+      key={tableTitle}
       className="row-span-3 col-span-full bg-white dark:text-white
         flex flex-col p-5 shadow-md border border-gray-200 rounded-xl transition duration-500
         hover:bg-gray-200 hover:scale-[1.01]

--- a/frontend_web/react+vite/src/modules/reports/components/ui/reports/categories/CategoriesReport.jsx
+++ b/frontend_web/react+vite/src/modules/reports/components/ui/reports/categories/CategoriesReport.jsx
@@ -1,33 +1,38 @@
-import ReturnButton from "../../ReturnButton";
+// Hooks
+// Components
+import KpisContainer from "../../KpisContainer";
+import ReportsContainer from "../../ReportsContainer";
+import ReportsTopSection from "../../ReportsTopSection";
+import TableCard from "../../TableCard";
+import ReportCard from "../../ReportCard";
 
-export default function CategoriesReport({
-  setReport,
-  setTopSectionVisiblity,
-}) {
-  setTopSectionVisiblity(false);
+export default function CategoriesReport({ setReport }) {
   return (
     <section className="w-full h-full flex flex-col gap-2 animate-blurUp">
-      <section className="flex items-center justify-between pl-3">
-        <ReturnButton onClick={() => setReport("home")} />
-        <div className="flex items-center justify-end gap-1.5 pr-3">
-          <button className="px-4 py-1.5 bg-gray-100 rounded-xl shadow-xl">
-            7d
-          </button>
-          <button className="px-4 py-1.5 border rounded-xl shadow-md">
-            30d
-          </button>
-          <button className="px-4 py-1.5 border rounded-xl shadow-md">
-            6m
-          </button>
-          <button className="px-4 py-1.5 border rounded-xl shadow-md">
-            1a
-          </button>
-        </div>
-      </section>
-      <section
-        className="h-[91%] w-full grid p-3 pt-2 gap-3
-                          xl:grid-cols-12 xl:grid-rows-7"
-      ></section>
+      <ReportsTopSection setReport={setReport} />
+
+      <ReportsContainer
+        reportsName={"Productos"}
+        reportsDate={"16 De Marzo - 23 De Marzo 2025"}
+      >
+        {/* Cards o KPIs principales */}
+        <KpisContainer
+          firstKpiName={""}
+          firstKpiValue={""}
+          secondKpiName={""}
+          secondKpiValue={""}
+          thirdKpiName={""}
+          thirdKpiValue={""}
+          fourthKpiName={""}
+          fourthKpiValue={""}
+        />
+
+        <ReportCard name={"Crecimiento Mensual"} colSpan={12}></ReportCard>
+
+        <ReportCard name={"Distribución"} colSpan={4}></ReportCard>
+
+        <TableCard tableTitle={"Productos recientes"}></TableCard>
+      </ReportsContainer>
     </section>
   );
 }

--- a/frontend_web/react+vite/src/modules/reports/components/ui/reports/products/ProductsAreaChart.jsx
+++ b/frontend_web/react+vite/src/modules/reports/components/ui/reports/products/ProductsAreaChart.jsx
@@ -1,0 +1,43 @@
+import {
+  ResponsiveContainer,
+  AreaChart,
+  Area,
+  Tooltip,
+  YAxis,
+  XAxis,
+} from "recharts";
+import { useProductsAreaData } from "../../../../hooks/products/useProductsAreaData";
+
+export default function ProductsAreaChart() {
+  const { productsData } = useProductsAreaData();
+  return (
+    <ResponsiveContainer width={"100%"} height={290}>
+      <AreaChart
+        data={productsData}
+        height={"70%"}
+        width={"100%"}
+        responsive
+        margin={{ left: 10, right: 5 }}
+      >
+        <YAxis width="auto" fontSize={"10px"} />
+        <XAxis fontSize={"10px"} dataKey={"month"} />
+        <Tooltip />
+
+        {/* Grandiente aplicada al gráfico */}
+        <defs>
+          <linearGradient id="color" x1="0" y1="0" x2="0" y2="1">
+            <stop offset="5%" stopColor="#1447e6" stopOpacity={1} />
+            <stop offset="95%" stopColor="#1447e6" stopOpacity={0.1} />
+          </linearGradient>
+        </defs>
+
+        <Area
+          type={"natural"}
+          dataKey={"products"}
+          stroke="#1447e6"
+          fill="url(#color)"
+        />
+      </AreaChart>
+    </ResponsiveContainer>
+  );
+}

--- a/frontend_web/react+vite/src/modules/reports/components/ui/reports/products/ProductsAreaChart.jsx
+++ b/frontend_web/react+vite/src/modules/reports/components/ui/reports/products/ProductsAreaChart.jsx
@@ -8,13 +8,13 @@ import {
 } from "recharts";
 import { useProductsAreaData } from "../../../../hooks/products/useProductsAreaData";
 
-export default function ProductsAreaChart() {
-  const { productsData } = useProductsAreaData();
+export default function ProductsAreaChart({ period }) {
+  const { productsData } = useProductsAreaData(period);
   return (
     <ResponsiveContainer width={"100%"} height={290}>
       <AreaChart
         data={productsData}
-        height={"70%"}
+        height={"auto"}
         width={"100%"}
         responsive
         margin={{ left: 10, right: 5 }}

--- a/frontend_web/react+vite/src/modules/reports/components/ui/reports/products/ProductsPieChart.jsx
+++ b/frontend_web/react+vite/src/modules/reports/components/ui/reports/products/ProductsPieChart.jsx
@@ -1,0 +1,33 @@
+import { useProductsPieData } from "../../../../hooks/products/useProductsPieData";
+import {
+  ResponsiveContainer,
+  PieChart,
+  Pie,
+  Cell,
+  Tooltip,
+  Legend,
+} from "recharts";
+
+export default function ProductsPieChart({ period }) {
+  const { productsData } = useProductsPieData(period);
+  return (
+    <ResponsiveContainer width={"100%"} height={280}>
+      <PieChart width={"100%"} height={"100%"}>
+        <Tooltip />
+        <Pie
+          data={productsData}
+          dataKey={"value"}
+          nameKey={"name"}
+          cornerRadius={"10%"}
+          paddingAngle={1}
+          innerRadius="80"
+          outerRadius="140"
+        >
+          {productsData.map((item) => (
+            <Cell key={item.name} fill={item.color} stroke="#1447e6" />
+          ))}
+        </Pie>
+      </PieChart>
+    </ResponsiveContainer>
+  );
+}

--- a/frontend_web/react+vite/src/modules/reports/components/ui/reports/products/ProductsReport.jsx
+++ b/frontend_web/react+vite/src/modules/reports/components/ui/reports/products/ProductsReport.jsx
@@ -1,30 +1,51 @@
-import ReturnButton from "../../ReturnButton";
+// Hooks
+import { useProductsData } from "../../../../hooks/products/useProductsData";
+// Components
+import KpisContainer from "../../KpisContainer";
+import ReportsContainer from "../../ReportsContainer";
+import ReportsTopSection from "../../ReportsTopSection";
+import TableCard from "../../TableCard";
+import ReportCard from "../../ReportCard";
+import ProductsTable from "./ProductsTable";
+import ProductsPieChart from "./ProductsPieChart";
+import ProductsAreaChart from "./ProductsAreaChart";
 
-export default function ProductsReport({ setReport, setTopSectionVisiblity }) {
-  setTopSectionVisiblity(false);
+export default function ProductsReport({ setReport }) {
+  const { productsData } = useProductsData();
   return (
     <section className="w-full h-full flex flex-col gap-2 animate-blurUp">
-      <section className="flex items-center justify-between pl-3">
-        <ReturnButton onClick={() => setReport("home")} />
-        <div className="flex items-center justify-end gap-1.5 pr-3">
-          <button className="px-4 py-1.5 bg-gray-100 rounded-xl shadow-xl">
-            7d
-          </button>
-          <button className="px-4 py-1.5 border rounded-xl shadow-md">
-            30d
-          </button>
-          <button className="px-4 py-1.5 border rounded-xl shadow-md">
-            6m
-          </button>
-          <button className="px-4 py-1.5 border rounded-xl shadow-md">
-            1a
-          </button>
-        </div>
-      </section>
-      <section
-        className="h-[91%] w-full grid p-3 pt-2 gap-3
-                      xl:grid-cols-12 xl:grid-rows-7"
-      ></section>
+      <ReportsTopSection setReport={setReport} />
+
+      {productsData.map((item) => (
+        <ReportsContainer
+          reportsName={"Productos"}
+          reportsDate={"16 De Marzo - 23 De Marzo 2025"}
+        >
+          {/* Cards o KPIs principales */}
+          <KpisContainer
+            firstKpiName={"Total productos"}
+            firstKpiValue={item.total_products}
+            secondKpiName={"Recientes"}
+            secondKpiValue={item.recent_products}
+            thirdKpiName={"En garantía"}
+            thirdKpiValue={item.warranties_products}
+            fourthKpiName={"En salidas"}
+            fourthKpiValue={item.transformations_products}
+          />
+
+          <ReportCard name={"Crecimiento Mensual"} colSpan={12}>
+            <ProductsAreaChart />
+          </ReportCard>
+
+          <ReportCard name={"Distribución"} colSpan={4}>
+            <ProductsPieChart />
+          </ReportCard>
+
+          <TableCard tableTitle={"Productos recientes"}>
+            <ProductsTable />
+          </TableCard>
+        </ReportsContainer>
+      ))}
     </section>
   );
 }

--- a/frontend_web/react+vite/src/modules/reports/components/ui/reports/products/ProductsReport.jsx
+++ b/frontend_web/react+vite/src/modules/reports/components/ui/reports/products/ProductsReport.jsx
@@ -1,4 +1,5 @@
 // Hooks
+import { useState } from "react";
 import { useProductsData } from "../../../../hooks/products/useProductsData";
 // Components
 import KpisContainer from "../../KpisContainer";
@@ -12,9 +13,15 @@ import ProductsAreaChart from "./ProductsAreaChart";
 
 export default function ProductsReport({ setReport }) {
   const { productsData } = useProductsData();
+  const [period, setPeriod] = useState("30d");
   return (
     <section className="w-full h-full flex flex-col gap-2 animate-blurUp">
-      <ReportsTopSection setReport={setReport} />
+      <ReportsTopSection
+        setReport={setReport}
+        periods={["7d", "30d", "6m", "1a"]}
+        setPeriod={setPeriod}
+        currentPeriod={period}
+      />
 
       {productsData.map((item) => (
         <ReportsContainer
@@ -33,12 +40,12 @@ export default function ProductsReport({ setReport }) {
             fourthKpiValue={item.transformations_products}
           />
 
-          <ReportCard name={"Crecimiento Mensual"} colSpan={12}>
-            <ProductsAreaChart />
+          <ReportCard name={"Crecimiento"} colSpan={12}>
+            <ProductsAreaChart period={period} />
           </ReportCard>
 
           <ReportCard name={"Distribución"} colSpan={4}>
-            <ProductsPieChart />
+            <ProductsPieChart period={period} />
           </ReportCard>
 
           <TableCard tableTitle={"Productos recientes"}>

--- a/frontend_web/react+vite/src/modules/reports/components/ui/reports/products/ProductsTable.jsx
+++ b/frontend_web/react+vite/src/modules/reports/components/ui/reports/products/ProductsTable.jsx
@@ -6,24 +6,25 @@ export default function ProductsTable() {
     <table className="w-full h-full pt-2">
       <thead className="h-[30px]">
         <tr className="border-b pb-1 text-sm dark:border-[#94909028]">
-          <th className="font-normal text-start pl-4">Fecha de entrada</th>
           <th className="font-normal text-start pl-4">Modelo</th>
           <th className="font-normal text-start pl-4">Serial</th>
           <th className="font-normal text-start pl-4">Marca</th>
+          <th className="font-normal text-start pl-4">Fecha de entrada</th>
         </tr>
       </thead>
       {productsData.map((product) => (
         <tbody>
           <tr className="pb-1 text-sm border-b dark:border-[#94909028]">
-            <th className="font-normal text-start pl-4">
-              {product.input_date}
-            </th>
             <th className="font-normal text-start pl-4">{product.model}</th>
             <th className="font-normal text-start pl-4">{product.serial}</th>
             <th className="font-normal text-start pl-4">{product.brand}</th>
+            <th className="font-normal text-start pl-4">
+              {product.input_date}
+            </th>
           </tr>
         </tbody>
       ))}
     </table>
   );
 }
+  

--- a/frontend_web/react+vite/src/modules/reports/components/ui/reports/subcategories/SubcategoriesReport.jsx
+++ b/frontend_web/react+vite/src/modules/reports/components/ui/reports/subcategories/SubcategoriesReport.jsx
@@ -1,33 +1,38 @@
-import ReturnButton from "../../ReturnButton";
+// Hooks
+// Components
+import KpisContainer from "../../KpisContainer";
+import ReportsContainer from "../../ReportsContainer";
+import ReportsTopSection from "../../ReportsTopSection";
+import TableCard from "../../TableCard";
+import ReportCard from "../../ReportCard";
 
-export default function SubcategoriesReport({
-  setReport,
-  setTopSectionVisiblity,
-}) {
-  setTopSectionVisiblity(false);
+export default function SubcategoriesReport({ setReport }) {
   return (
     <section className="w-full h-full flex flex-col gap-2 animate-blurUp">
-      <section className="flex items-center justify-between pl-3">
-        <ReturnButton onClick={() => setReport("home")} />
-        <div className="flex items-center justify-end gap-1.5 pr-3">
-          <button className="px-4 py-1.5 bg-gray-100 rounded-xl shadow-xl">
-            7d
-          </button>
-          <button className="px-4 py-1.5 border rounded-xl shadow-md">
-            30d
-          </button>
-          <button className="px-4 py-1.5 border rounded-xl shadow-md">
-            6m
-          </button>
-          <button className="px-4 py-1.5 border rounded-xl shadow-md">
-            1a
-          </button>
-        </div>
-      </section>
-      <section
-        className="h-[91%] w-full grid p-3 pt-2 gap-3
-                          xl:grid-cols-12 xl:grid-rows-7"
-      ></section>
+      <ReportsTopSection setReport={setReport} />
+
+      <ReportsContainer
+        reportsName={"Productos"}
+        reportsDate={"16 De Marzo - 23 De Marzo 2025"}
+      >
+        {/* Cards o KPIs principales */}
+        <KpisContainer
+          firstKpiName={""}
+          firstKpiValue={""}
+          secondKpiName={""} 
+          secondKpiValue={""}
+          thirdKpiName={""}
+          thirdKpiValue={""}
+          fourthKpiName={""}
+          fourthKpiValue={""}
+        />
+
+        <ReportCard name={"Crecimiento Mensual"} colSpan={12}></ReportCard>
+
+        <ReportCard name={"Distribución"} colSpan={4}></ReportCard>
+
+        <TableCard tableTitle={"Productos recientes"}></TableCard>
+      </ReportsContainer>
     </section>
   );
 }

--- a/frontend_web/react+vite/src/modules/reports/components/ui/reports/suppliers/SuppliersReport.jsx
+++ b/frontend_web/react+vite/src/modules/reports/components/ui/reports/suppliers/SuppliersReport.jsx
@@ -1,30 +1,38 @@
-import ReturnButton from "../../ReturnButton";
+// Hooks
+// Components
+import KpisContainer from "../../KpisContainer";
+import ReportsContainer from "../../ReportsContainer";
+import ReportsTopSection from "../../ReportsTopSection";
+import TableCard from "../../TableCard";
+import ReportCard from "../../ReportCard";
 
-export default function SuppliersReport({ setReport, setTopSectionVisiblity }) {
-  setTopSectionVisiblity(false);
+export default function SuppliersReport({ setReport }) {
   return (
     <section className="w-full h-full flex flex-col gap-2 animate-blurUp">
-      <section className="flex items-center justify-between pl-3">
-        <ReturnButton onClick={() => setReport("home")} />
-        <div className="flex items-center justify-end gap-1.5 pr-3">
-          <button className="px-4 py-1.5 bg-gray-100 rounded-xl shadow-xl">
-            7d
-          </button>
-          <button className="px-4 py-1.5 border rounded-xl shadow-md">
-            30d
-          </button>
-          <button className="px-4 py-1.5 border rounded-xl shadow-md">
-            6m
-          </button>
-          <button className="px-4 py-1.5 border rounded-xl shadow-md">
-            1a
-          </button>
-        </div>
-      </section>
-      <section
-        className="h-[91%] w-full grid p-3 pt-2 gap-3
-                          xl:grid-cols-12 xl:grid-rows-7"
-      ></section>
+      <ReportsTopSection setReport={setReport} />
+
+      <ReportsContainer
+        reportsName={"Productos"}
+        reportsDate={"16 De Marzo - 23 De Marzo 2025"}
+      >
+        {/* Cards o KPIs principales */}
+        <KpisContainer
+          firstKpiName={""}
+          firstKpiValue={""}
+          secondKpiName={""}
+          secondKpiValue={""}
+          thirdKpiName={""}
+          thirdKpiValue={""}
+          fourthKpiName={""}
+          fourthKpiValue={""}
+        />
+
+        <ReportCard name={"Crecimiento Mensual"} colSpan={12}></ReportCard>
+
+        <ReportCard name={"Distribución"} colSpan={4}></ReportCard>
+
+        <TableCard tableTitle={"Productos recientes"}></TableCard>
+      </ReportsContainer>
     </section>
   );
 }

--- a/frontend_web/react+vite/src/modules/reports/components/ui/reports/transformations/TransformationsReport.jsx
+++ b/frontend_web/react+vite/src/modules/reports/components/ui/reports/transformations/TransformationsReport.jsx
@@ -1,33 +1,38 @@
-import ReturnButton from "../../ReturnButton";
+// Hooks
+// Components
+import KpisContainer from "../../KpisContainer";
+import ReportsContainer from "../../ReportsContainer";
+import ReportsTopSection from "../../ReportsTopSection";
+import TableCard from "../../TableCard";
+import ReportCard from "../../ReportCard";
 
-export default function TransformationsReport({
-  setReport,
-  setTopSectionVisiblity,
-}) {
-  setTopSectionVisiblity(false);
+export default function TransformationsReport({ setReport }) {
   return (
     <section className="w-full h-full flex flex-col gap-2 animate-blurUp">
-      <section className="flex items-center justify-between pl-3">
-        <ReturnButton onClick={() => setReport("home")} />
-        <div className="flex items-center justify-end gap-1.5 pr-3">
-          <button className="px-4 py-1.5 bg-gray-100 rounded-xl shadow-xl">
-            7d
-          </button>
-          <button className="px-4 py-1.5 border rounded-xl shadow-md">
-            30d
-          </button>
-          <button className="px-4 py-1.5 border rounded-xl shadow-md">
-            6m
-          </button>
-          <button className="px-4 py-1.5 border rounded-xl shadow-md">
-            1a
-          </button>
-        </div>
-      </section>
-      <section
-        className="h-[91%] w-full grid p-3 pt-2 gap-3
-                  xl:grid-cols-12 xl:grid-rows-7"
-      ></section>
+      <ReportsTopSection setReport={setReport} />
+
+      <ReportsContainer
+        reportsName={"Productos"}
+        reportsDate={"16 De Marzo - 23 De Marzo 2025"}
+      >
+        {/* Cards o KPIs principales */}
+        <KpisContainer
+          firstKpiName={""}
+          firstKpiValue={""}
+          secondKpiName={""}
+          secondKpiValue={""}
+          thirdKpiName={""}
+          thirdKpiValue={""}
+          fourthKpiName={""}
+          fourthKpiValue={""}
+        />
+
+        <ReportCard name={"Crecimiento Mensual"} colSpan={12}></ReportCard>
+
+        <ReportCard name={"Distribución"} colSpan={4}></ReportCard>
+
+        <TableCard tableTitle={"Productos recientes"}></TableCard>
+      </ReportsContainer>
     </section>
   );
 }

--- a/frontend_web/react+vite/src/modules/reports/components/ui/reports/users/UsersAreaChart.jsx
+++ b/frontend_web/react+vite/src/modules/reports/components/ui/reports/users/UsersAreaChart.jsx
@@ -8,8 +8,8 @@ import {
 } from "recharts";
 import { useUsersAreaData } from "../../../../hooks/users/useUsersAreaData";
 
-export default function UsersAreaChart() {
-  const { usersData } = useUsersAreaData();
+export default function UsersAreaChart({ period }) {
+  const { usersData } = useUsersAreaData(period);
   return (
     <ResponsiveContainer width={"100%"} height={290}>
       <AreaChart

--- a/frontend_web/react+vite/src/modules/reports/components/ui/reports/users/UsersPieChart.jsx
+++ b/frontend_web/react+vite/src/modules/reports/components/ui/reports/users/UsersPieChart.jsx
@@ -18,7 +18,7 @@ export default function UsersPieChart({ period }) {
           data={usersData}
           cy={"85%"}
           dataKey={"users"}
-          nameKey={"name"}
+          nameKey={"rol"}
           startAngle={180}
           endAngle={0}
           cornerRadius={"10%"}
@@ -33,7 +33,7 @@ export default function UsersPieChart({ period }) {
         <Legend
           layout="vertical"
           formatter={(value, entry) => {
-            return `${value}: ${entry.payload.value}`;
+            return `${entry.payload.rol}: ${entry.payload.users}`;
           }}
         />
       </PieChart>

--- a/frontend_web/react+vite/src/modules/reports/components/ui/reports/users/UsersPieChart.jsx
+++ b/frontend_web/react+vite/src/modules/reports/components/ui/reports/users/UsersPieChart.jsx
@@ -8,8 +8,8 @@ import {
   Legend,
 } from "recharts";
 
-export default function UsersPieChart() {
-  const { usersData } = useUsersPieData();
+export default function UsersPieChart({ period }) {
+  const { usersData } = useUsersPieData(period);
   return (
     <ResponsiveContainer width={"100%"} height={280}>
       <PieChart width={"100%"} height={"100%"}>
@@ -17,7 +17,7 @@ export default function UsersPieChart() {
         <Pie
           data={usersData}
           cy={"85%"}
-          dataKey={"value"}
+          dataKey={"users"}
           nameKey={"name"}
           startAngle={180}
           endAngle={0}

--- a/frontend_web/react+vite/src/modules/reports/components/ui/reports/users/UsersReport.jsx
+++ b/frontend_web/react+vite/src/modules/reports/components/ui/reports/users/UsersReport.jsx
@@ -1,76 +1,36 @@
 // Hooks
 import { useUsersData } from "../../../../hooks/users/useUsersData";
-// Icons
-import { actionsIcons } from "../../../../../../assets/icons/mainIcons";
 // Components
-import KpiCard from "../../KpiCard";
-import ReportCard from "../../ReportCard";
-import TableCard from "../../TableCard";
 import UsersTable from "./UsersTable";
+import TableCard from "../../TableCard";
+import ReportCard from "../../ReportCard";
 import UsersPieChart from "./UsersPieChart";
 import UsersAreaChart from "./UsersAreaChart";
-import ReturnButton from "../../ReturnButton";
+import KpisContainer from "../../KpisContainer";
+import ReportsContainer from "../../ReportsContainer";
+import ReportsTopSection from "../../ReportsTopSection";
 
-export default function UsersReport({ setReport, setTopSectionVisiblity }) {
+export default function UsersReport({ setReport }) {
   const { usersData } = useUsersData();
-  setTopSectionVisiblity(false);
   return (
     <section className="w-full h-full flex flex-col gap-2 animate-blurUp">
-      <section className="flex items-center justify-between pl-3 dark:text-white">
-        <ReturnButton onClick={() => setReport("home")} />
-        <div className="flex items-center justify-end gap-1.5 pr-3">
-          <div className="flex gap-1 py-0.5 border rounded-xl text-sm font-medium bg-gray-200 
-          dark:bg-gray-950 dark:border-neutral-800 ">
-            <button className="px-4 py-1.5 rounded-lg">7d</button>
-            <button className="px-4 py-1.5 rounded-xl bg-white shadow-md dark:text-black">
-              30d
-            </button>
-            <button className="px-4 py-1.5 rounded-lg">6m</button>
-            <button className="px-4 py-1.5 rounded-lg">1a</button>
-          </div>
-          <button
-            className="flex items-center px-4 py-2 gap-2 border rounded-xl shadow-md text-sm 
-          dark:text-white dark:border-neutral-800"
-          >
-            <img
-              src={actionsIcons.uploadIcon}
-              alt=""
-              className="w-5 h-5 dark:invert"
-            />
-            <span>Exportar</span>
-          </button>
-        </div>
-      </section>
+      <ReportsTopSection setReport={setReport} />
+
       {usersData.map((item) => (
-        <section
-          className="h-full w-full grid p-3 pt-2
-              xl:grid-cols-[repeat(16,_1fr)] xl:grid-rows-7
-              gap-3"
+        <ReportsContainer
+          reportsName={"usuarios"}
+          reportsDate={"16 De Marzo - 23 De Marzo 2025"}
         >
-          <section className="col-span-4 row-span-1 flex flex-col justify-center items-start dark:text-white">
-            <span className="text-2xl font-medium">Reporte de Usuarios</span>
-            <span className="text-sm">16 De Marzo - 23 De Marzo 2025</span>
-          </section>
           {/* Cards o KPIs principales */}
-          <KpiCard
-            name={"Total usuarios"}
-            metricValue={item.total_users}
-            percentValue={"+12%"}
-          />
-          <KpiCard
-            name={"Activos"}
-            metricValue={item.active_users}
-            percentValue={"+12%"}
-          />
-          <KpiCard
-            name={"Deshabilitados"}
-            metricValue={item.inactive_users}
-            percentValue={"+12%"}
-          />
-          <KpiCard
-            name={"Nuevos este mes"}
-            metricValue={item.recent_users}
-            percentValue={"+12%"}
+          <KpisContainer
+            firstKpiName={"Total usuarios"}
+            firstKpiValue={item.total_users}
+            secondKpiName={"Activos"}
+            secondKpiValue={item.active_users}
+            thirdKpiName={"Deshabilitados"}
+            thirdKpiValue={item.inactive_users}
+            fourthKpiName={"Nuevos este mes"}
+            fourthKpiValue={item.recent_users}
           />
 
           <ReportCard name={"Crecimiento Mensual"} colSpan={12}>
@@ -84,7 +44,7 @@ export default function UsersReport({ setReport, setTopSectionVisiblity }) {
           <TableCard tableTitle={"Usuarios recientes"}>
             <UsersTable />
           </TableCard>
-        </section>
+        </ReportsContainer>
       ))}
     </section>
   );

--- a/frontend_web/react+vite/src/modules/reports/components/ui/reports/users/UsersReport.jsx
+++ b/frontend_web/react+vite/src/modules/reports/components/ui/reports/users/UsersReport.jsx
@@ -1,4 +1,5 @@
 // Hooks
+import { useState } from "react";
 import { useUsersData } from "../../../../hooks/users/useUsersData";
 // Components
 import UsersTable from "./UsersTable";
@@ -12,9 +13,15 @@ import ReportsTopSection from "../../ReportsTopSection";
 
 export default function UsersReport({ setReport }) {
   const { usersData } = useUsersData();
+  const [period, setPeriod] = useState("30d");
   return (
     <section className="w-full h-full flex flex-col gap-2 animate-blurUp">
-      <ReportsTopSection setReport={setReport} />
+      <ReportsTopSection
+        setReport={setReport}
+        periods={["7d", "30d", "6m", "1a"]}
+        setPeriod={setPeriod}
+        currentPeriod={period}
+      />
 
       {usersData.map((item) => (
         <ReportsContainer
@@ -34,11 +41,11 @@ export default function UsersReport({ setReport }) {
           />
 
           <ReportCard name={"Crecimiento Mensual"} colSpan={12}>
-            <UsersAreaChart />
+            <UsersAreaChart period={period} />
           </ReportCard>
 
           <ReportCard name={"Distribución"} colSpan={4}>
-            <UsersPieChart />
+            <UsersPieChart period={period} />
           </ReportCard>
 
           <TableCard tableTitle={"Usuarios recientes"}>

--- a/frontend_web/react+vite/src/modules/reports/components/ui/reports/warranties/WarrantiesReport.jsx
+++ b/frontend_web/react+vite/src/modules/reports/components/ui/reports/warranties/WarrantiesReport.jsx
@@ -1,33 +1,38 @@
-import ReturnButton from "../../ReturnButton";
+// Hooks
+// Components
+import KpisContainer from "../../KpisContainer";
+import ReportsContainer from "../../ReportsContainer";
+import ReportsTopSection from "../../ReportsTopSection";
+import TableCard from "../../TableCard";
+import ReportCard from "../../ReportCard";
 
-export default function WarrantiesReport({
-  setReport,
-  setTopSectionVisiblity,
-}) {
-  setTopSectionVisiblity(false);
+export default function WarrantiesReport({ setReport }) {
   return (
     <section className="w-full h-full flex flex-col gap-2 animate-blurUp">
-      <section className="flex items-center justify-between pl-3">
-        <ReturnButton onClick={() => setReport("home")} />
-        <div className="flex items-center justify-end gap-1.5 pr-3">
-          <button className="px-4 py-1.5 bg-gray-100 rounded-xl shadow-xl">
-            7d
-          </button>
-          <button className="px-4 py-1.5 border rounded-xl shadow-md">
-            30d
-          </button>
-          <button className="px-4 py-1.5 border rounded-xl shadow-md">
-            6m
-          </button>
-          <button className="px-4 py-1.5 border rounded-xl shadow-md">
-            1a
-          </button>
-        </div>
-      </section>
-      <section
-        className="h-[91%] w-full grid p-3 pt-2 gap-3
-                      xl:grid-cols-12 xl:grid-rows-7"
-      ></section>
+      <ReportsTopSection setReport={setReport} />
+
+      <ReportsContainer
+        reportsName={"Productos"}
+        reportsDate={"16 De Marzo - 23 De Marzo 2025"}
+      >
+        {/* Cards o KPIs principales */}
+        <KpisContainer
+          firstKpiName={"Total productos"}
+          firstKpiValue={""}
+          secondKpiName={"Activos"}
+          secondKpiValue={""}
+          thirdKpiName={"Deshabilitados"}
+          thirdKpiValue={""}
+          fourthKpiName={"Nuevos este mes"}
+          fourthKpiValue={""}
+        />
+
+        <ReportCard name={"Crecimiento Mensual"} colSpan={12}></ReportCard>
+
+        <ReportCard name={"Distribución"} colSpan={4}></ReportCard>
+
+        <TableCard tableTitle={"Productos recientes"}></TableCard>
+      </ReportsContainer>
     </section>
   );
 }

--- a/frontend_web/react+vite/src/modules/reports/hooks/products/useProductsAreaData.js
+++ b/frontend_web/react+vite/src/modules/reports/hooks/products/useProductsAreaData.js
@@ -1,0 +1,35 @@
+import { useEffect, useRef, useState } from "react";
+import { monthNames } from "../../../../constants/dateConstants";
+import { getProductsAreaChartService } from "../../services/products/getProductsAreaChartService";
+
+export function useProductsAreaData() {
+  const [productsData, setProductsData] = useState([]);
+  const [error, setError] = useState(false);
+  const controllerRef = useRef(null);
+
+  useEffect(() => {
+    async function fetchProductsData() {
+      controllerRef.current?.abort();
+      controllerRef.current = new AbortController();
+
+      try {
+        const response = await getProductsAreaChartService(
+          controllerRef.current.signal,
+        );
+        const data = response.map((row) => ({
+          month: monthNames[row.month_num - 1],
+          products: row.products,
+        }));
+        setProductsData(data);
+      } catch (error) {
+        if (error.name === "AbortError") return;
+        setError(error.message);
+      }
+    }
+
+    fetchProductsData();
+    return () => controllerRef.current?.abort();
+  }, []);
+
+  return { productsData, error };
+}

--- a/frontend_web/react+vite/src/modules/reports/hooks/products/useProductsAreaData.js
+++ b/frontend_web/react+vite/src/modules/reports/hooks/products/useProductsAreaData.js
@@ -2,7 +2,7 @@ import { useEffect, useRef, useState } from "react";
 import { monthNames } from "../../../../constants/dateConstants";
 import { getProductsAreaChartService } from "../../services/products/getProductsAreaChartService";
 
-export function useProductsAreaData() {
+export function useProductsAreaData(period) {
   const [productsData, setProductsData] = useState([]);
   const [error, setError] = useState(false);
   const controllerRef = useRef(null);
@@ -14,6 +14,7 @@ export function useProductsAreaData() {
 
       try {
         const response = await getProductsAreaChartService(
+          period,
           controllerRef.current.signal,
         );
         const data = response.map((row) => ({
@@ -29,7 +30,7 @@ export function useProductsAreaData() {
 
     fetchProductsData();
     return () => controllerRef.current?.abort();
-  }, []);
+  }, [period]);
 
   return { productsData, error };
 }

--- a/frontend_web/react+vite/src/modules/reports/hooks/products/useProductsData.js
+++ b/frontend_web/react+vite/src/modules/reports/hooks/products/useProductsData.js
@@ -1,0 +1,28 @@
+import { useEffect, useRef, useState } from "react";
+import { getProductsDataService } from "../../services/products/getProductsDataService";
+
+export function useProductsData() {
+  const [productsData, setProductsData] = useState([]);
+  const [error, setError] = useState(false);
+  const controllerRef = useRef(null);
+
+  useEffect(() => {
+    async function fetchProductsData() {
+      controllerRef.current?.abort();
+      controllerRef.current = new AbortController();
+
+      try {
+        const data = await getProductsDataService(controllerRef.current.signal);
+        setProductsData(data);
+      } catch (error) {
+        if (error.name === "AbortError") return;
+        setError(error.message);
+      }
+    }
+
+    fetchProductsData();
+    return () => controllerRef.current?.abort();
+  }, []);
+
+  return { productsData, error };
+}

--- a/frontend_web/react+vite/src/modules/reports/hooks/products/useProductsPieData.js
+++ b/frontend_web/react+vite/src/modules/reports/hooks/products/useProductsPieData.js
@@ -1,0 +1,38 @@
+import { useEffect, useRef, useState } from "react";
+import { getProductsPieDataService } from "../../services/products/getProductsPieDataService";
+
+export function useProductsPieData(period) {
+  const [productsData, setProductsData] = useState([]);
+  const [error, setError] = useState(false);
+  const controllerRef = useRef(null);
+
+  useEffect(() => {
+    async function fetchProductsData() {
+      controllerRef.current?.abort();
+      controllerRef.current = new AbortController();
+
+      try {
+        const data = await getProductsPieDataService(
+          period,
+          controllerRef.current.signal,
+        );
+
+        const colors = ["#a5acfa", "#5769ff", "#4f5ff1", "#2f3ab5"];
+
+        const pieData = data.map((item, index) => ({
+          ...item,
+          color: colors[index % colors.length],
+        }));
+        setProductsData(pieData);
+      } catch (error) {
+        if (error.name === "AbortError") return;
+        setError(error.message);
+      }
+    }
+
+    fetchProductsData();
+    return () => controllerRef.current?.abort();
+  }, [period]);
+
+  return { productsData, error };
+}

--- a/frontend_web/react+vite/src/modules/reports/hooks/users/useUsersAreaData.js
+++ b/frontend_web/react+vite/src/modules/reports/hooks/users/useUsersAreaData.js
@@ -2,7 +2,7 @@ import { useEffect, useRef, useState } from "react";
 import { monthNames } from "../../../../constants/dateConstants";
 import { getUsersAreaChartService } from "../../services/users/getUsersAreaChartService";
 
-export function useUsersAreaData() {
+export function useUsersAreaData(period) {
   const [usersData, setUsersData] = useState([]);
   const [error, setError] = useState(false);
   const controllerRef = useRef(null);
@@ -14,6 +14,7 @@ export function useUsersAreaData() {
 
       try {
         const response = await getUsersAreaChartService(
+          period,
           controllerRef.current.signal,
         );
         const data = response.map((row) => ({
@@ -29,7 +30,7 @@ export function useUsersAreaData() {
 
     fetchUsersData();
     return () => controllerRef.current?.abort();
-  }, []);
+  }, [period]);
 
   return { usersData, error };
 }

--- a/frontend_web/react+vite/src/modules/reports/hooks/users/useUsersPieData.js
+++ b/frontend_web/react+vite/src/modules/reports/hooks/users/useUsersPieData.js
@@ -19,7 +19,8 @@ export function useUsersPieData(period) {
         const colors = ["#a5acfa", "#5769ff", "#4f5ff1", "#2f3ab5"];
 
         const pieData = data.map((item, index) => ({
-          ...item,
+          rol: item.rol_name,
+          users: item.users,
           color: colors[index % colors.length],
         }));
         setUsersData(pieData);

--- a/frontend_web/react+vite/src/modules/reports/hooks/users/useUsersPieData.js
+++ b/frontend_web/react+vite/src/modules/reports/hooks/users/useUsersPieData.js
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import { getUsersPieDataService } from "../../services/users/getUsersPieDataService";
 
-export function useUsersPieData() {
+export function useUsersPieData(period) {
   const [usersData, setUsersData] = useState([]);
   const [error, setError] = useState(false);
   const controllerRef = useRef(null);
@@ -12,13 +12,16 @@ export function useUsersPieData() {
       controllerRef.current = new AbortController();
 
       try {
-        const data = await getUsersPieDataService(controllerRef.current.signal);
-        const pieData = [
-          { name: "Administrador", value: data[0].users, color: "#a5acfa" },
-          { name: "Almacen", value: data[1].users, color: "#5769ff" },
-          { name: "Técnico", value: data[2].users, color: "#4f5ff1" },
-          { name: "Cliente", value: data[3].users, color: "#2f3ab5" },
-        ];
+        const data = await getUsersPieDataService(
+          period,
+          controllerRef.current.signal,
+        );
+        const colors = ["#a5acfa", "#5769ff", "#4f5ff1", "#2f3ab5"];
+
+        const pieData = data.map((item, index) => ({
+          ...item,
+          color: colors[index % colors.length],
+        }));
         setUsersData(pieData);
       } catch (error) {
         if (error.name === "AbortError") return;
@@ -28,7 +31,7 @@ export function useUsersPieData() {
 
     fetchUsersData();
     return () => controllerRef.current?.abort();
-  }, []);
+  }, [period]);
 
   return { usersData, error };
 }

--- a/frontend_web/react+vite/src/modules/reports/services/products/getProductsAreaChartService.js
+++ b/frontend_web/react+vite/src/modules/reports/services/products/getProductsAreaChartService.js
@@ -1,9 +1,9 @@
 import { apiRoutes } from "../../../../config/apiRoutes";
 import { getToken } from "../../../../utils/auth";
 
-export async function getProductsAreaChartService(signal) {
+export async function getProductsAreaChartService(period, signal) {
   const response = await fetch(
-    `${apiRoutes.apiUrl}${apiRoutes.reports}/get_monthly_products_growth`,
+    `${apiRoutes.apiUrl}${apiRoutes.reports}/get_monthly_products_growth/${period}`,
     {
       method: "GET",
       credentials: "include",

--- a/frontend_web/react+vite/src/modules/reports/services/products/getProductsAreaChartService.js
+++ b/frontend_web/react+vite/src/modules/reports/services/products/getProductsAreaChartService.js
@@ -1,0 +1,23 @@
+import { apiRoutes } from "../../../../config/apiRoutes";
+import { getToken } from "../../../../utils/auth";
+
+export async function getProductsAreaChartService(signal) {
+  const response = await fetch(
+    `${apiRoutes.apiUrl}${apiRoutes.reports}/get_monthly_products_growth`,
+    {
+      method: "GET",
+      credentials: "include",
+      headers: {
+        Authorization: getToken(),
+      },
+      signal,
+    },
+  );
+
+  if (!response.ok) {
+    throw new Error("Error en la petición");
+  }
+  const data = await response.json();
+
+  return data.data;
+}

--- a/frontend_web/react+vite/src/modules/reports/services/products/getProductsDataService.js
+++ b/frontend_web/react+vite/src/modules/reports/services/products/getProductsDataService.js
@@ -1,0 +1,23 @@
+import { apiRoutes } from "../../../../config/apiRoutes";
+import { getToken } from "../../../../utils/auth";
+
+export async function getProductsDataService(signal) {
+  const response = await fetch(
+    `${apiRoutes.apiUrl}${apiRoutes.reports}/get_products_by_status`,
+    {
+      method: "GET",
+      credentials: "include",
+      headers: {
+        Authorization: getToken(),
+      },
+      signal,
+    },
+  );
+
+  if (!response.ok) {
+    throw new Error("Error en la petición");
+  }
+  const data = await response.json();
+
+  return data.data;
+}

--- a/frontend_web/react+vite/src/modules/reports/services/products/getProductsPieDataService.js
+++ b/frontend_web/react+vite/src/modules/reports/services/products/getProductsPieDataService.js
@@ -1,0 +1,23 @@
+import { apiRoutes } from "../../../../config/apiRoutes";
+import { getToken } from "../../../../utils/auth";
+
+export async function getProductsPieDataService(period, signal) {
+  const response = await fetch(
+    `${apiRoutes.apiUrl}${apiRoutes.reports}/get_products_by_brand/${period}`,
+    {
+      method: "GET",
+      credentials: "include",
+      headers: {
+        Authorization: getToken(),
+      },
+      signal,
+    },
+  );
+
+  if (!response.ok) {
+    throw new Error("Error en la petición");
+  }
+  const data = await response.json();
+
+  return data.data;
+}

--- a/frontend_web/react+vite/src/modules/reports/services/products/getProductsTableDataService.js
+++ b/frontend_web/react+vite/src/modules/reports/services/products/getProductsTableDataService.js
@@ -3,9 +3,10 @@ import { getToken } from "../../../../utils/auth";
 
 export async function getProductsTableDataService(signal) {
   const response = await fetch(
-    `${apiRoutes.apiUrl}${apiRoutes.reports}/get_products`,
+    `${apiRoutes.apiUrl}${apiRoutes.reports}/get_recent_products`,
     {
       method: "GET",
+      credentials: "include",
       headers: {
         Authorization: getToken(),
       },

--- a/frontend_web/react+vite/src/modules/reports/services/users/getUsersAreaChartService.js
+++ b/frontend_web/react+vite/src/modules/reports/services/users/getUsersAreaChartService.js
@@ -1,9 +1,9 @@
 import { apiRoutes } from "../../../../config/apiRoutes";
 import { getToken } from "../../../../utils/auth";
 
-export async function getUsersAreaChartService(signal) {
+export async function getUsersAreaChartService(period, signal) {
   const response = await fetch(
-    `${apiRoutes.apiUrl}${apiRoutes.reports}/get_monthly_user_growth`,
+    `${apiRoutes.apiUrl}${apiRoutes.reports}/get_monthly_user_growth/${period}`,
     {
       method: "GET",
       credentials: "include",

--- a/frontend_web/react+vite/src/modules/reports/services/users/getUsersAreaChartService.js
+++ b/frontend_web/react+vite/src/modules/reports/services/users/getUsersAreaChartService.js
@@ -6,6 +6,7 @@ export async function getUsersAreaChartService(signal) {
     `${apiRoutes.apiUrl}${apiRoutes.reports}/get_monthly_user_growth`,
     {
       method: "GET",
+      credentials: "include",
       headers: {
         Authorization: getToken(),
       },

--- a/frontend_web/react+vite/src/modules/reports/services/users/getUsersDataService.js
+++ b/frontend_web/react+vite/src/modules/reports/services/users/getUsersDataService.js
@@ -6,6 +6,7 @@ export async function getUsersDataService(signal) {
     `${apiRoutes.apiUrl}${apiRoutes.reports}/get_users_by_status`,
     {
       method: "GET",
+      credentials: "include",
       headers: {
         Authorization: getToken(),
       },

--- a/frontend_web/react+vite/src/modules/reports/services/users/getUsersPieDataService.js
+++ b/frontend_web/react+vite/src/modules/reports/services/users/getUsersPieDataService.js
@@ -6,6 +6,7 @@ export async function getUsersPieDataService(signal) {
     `${apiRoutes.apiUrl}${apiRoutes.reports}/get_users_by_rol`,
     {
       method: "GET",
+      credentials: "include",
       headers: {
         Authorization: getToken(),
       },

--- a/frontend_web/react+vite/src/modules/reports/services/users/getUsersPieDataService.js
+++ b/frontend_web/react+vite/src/modules/reports/services/users/getUsersPieDataService.js
@@ -1,9 +1,9 @@
 import { apiRoutes } from "../../../../config/apiRoutes";
 import { getToken } from "../../../../utils/auth";
 
-export async function getUsersPieDataService(signal) {
+export async function getUsersPieDataService(period, signal) {
   const response = await fetch(
-    `${apiRoutes.apiUrl}${apiRoutes.reports}/get_users_by_rol`,
+    `${apiRoutes.apiUrl}${apiRoutes.reports}/get_users_by_rol/${period}`,
     {
       method: "GET",
       credentials: "include",

--- a/frontend_web/react+vite/src/modules/reports/services/users/getUsersTableDataService.js
+++ b/frontend_web/react+vite/src/modules/reports/services/users/getUsersTableDataService.js
@@ -3,9 +3,10 @@ import { getToken } from "../../../../utils/auth";
 
 export async function getUsersTableDataService(signal) {
   const response = await fetch(
-    `${apiRoutes.apiUrl}${apiRoutes.reports}/get_users`,
+    `${apiRoutes.apiUrl}${apiRoutes.reports}/get_recent_users`,
     {
       method: "GET",
+      credentials: "include",
       headers: {
         Authorization: getToken(),
       },


### PR DESCRIPTION
## Summary

Refactors the **Reports** area around shared building blocks (**`ReportsTopSection`**, **`ReportsContainer`**, **`KpisContainer`**, **`ExportButton`**) and simplifies **`ReportsPage`**. Aligns **Categories**, **Subcategories**, **Suppliers**, **Transformations**, and **Warranties** reports on that layout. Expands **Products** reporting with **`ProductsAreaChart`** / **`ProductsPieChart`**, hooks/services for area/pie/table/product data, **period selection** passed into charts, and **`credentials`** on fetches where needed. **Users** charts and services now take a **period** for dynamic data; **UsersReport** wires period selection through to charts. Includes small UX fixes (**`ReturnButton`** hover, **`TableCard`** key, **`SectionsContainer`** top-section behavior, **`ProductsTable`** “Fecha de entrada” column) and **`ReportCard`** / **`KpiCard`** cleanup.

## Changes

- **Layout / shell**: `ReportsPage.jsx` — leaner composition; new `ReportsTopSection`, `ReportsContainer`, `KpisContainer`, `ExportButton`.
- **Report pages**: `CategoriesReport`, `SubcategoriesReport`, `SuppliersReport`, `TransformationsReport`, `WarrantiesReport` — adopt shared top/KPI/container pattern; remove unused pieces.
- **Products**: `ProductsReport`, `ProductsAreaChart`, `ProductsPieChart`, `ProductsTable`; hooks `useProductsAreaData`, `useProductsData`, `useProductsPieData`; services for area/pie/table/recent products — **period-aware** charts and data loading.
- **Users**: `UsersReport`, `UsersAreaChart`, `UsersPieChart`; hooks/services updated for **period** + **`credentials`** on user data calls.
- **Shared UI**: `ReportCard`, `KpiCard`, `ReturnButton`, `SectionsContainer`, `TableCard` — small behavior/style fixes.

<img width="1919" height="997" alt="Captura de pantalla 2026-04-07 195138" src="https://github.com/user-attachments/assets/e11570c2-56c3-48ac-bb04-8562ab415e98" />
<img width="1918" height="995" alt="Captura de pantalla 2026-04-07 194553" src="https://github.com/user-attachments/assets/2bb33940-a6df-4c7c-91c6-f1200393b00e" />

