### PR TITLE
feat: add category description support in add/edit modals and more-info view

### DIFF
--- a/frontend_web/react+vite/src/modules/categories/components/modals/AddCategoryModal.jsx
+++ b/frontend_web/react+vite/src/modules/categories/components/modals/AddCategoryModal.jsx
@@ -13,6 +13,7 @@ export default function AddCategoryModal({ onClose }) {
   const [innerModal, setInnerModal] = useState(null);
   const { form, loading, handleChange, handleSubmit } = useCreateCategory({
     name: "",
+    description: "",
   });
   return (
     <section className="flex flex-col items-center">
@@ -21,10 +22,18 @@ export default function AddCategoryModal({ onClose }) {
           onChange={handleChange}
           value={form.name}
           name={"name"}
-          labelText={"Nombre de la Categoría"}
-          placeholder={"Electrodomésticos"}
+          labelText={"Nombre"}
+          placeholder={"Nombre"}
           id={"category_name"}
           autoComplete="off"
+        />
+        <FormField
+          onChange={handleChange}
+          value={form.description}
+          name={"description"}
+          placeholder={"Que productos almacena"}
+          labelText={"Descripción"}
+          id={"category_description"}
         />
       </form>
 
@@ -47,7 +56,7 @@ export default function AddCategoryModal({ onClose }) {
           confirmButtonText={"Volver a la página"}
           onClose={() => {
             setInnerModal(null);
-            onClose();            
+            onClose();
           }}
         />
       )}

--- a/frontend_web/react+vite/src/modules/categories/components/modals/EditCategoryInfoModal.jsx
+++ b/frontend_web/react+vite/src/modules/categories/components/modals/EditCategoryInfoModal.jsx
@@ -15,6 +15,7 @@ export default function EditCategoryInfoModal({ category, onClose}) {
     category.category_id,
     {
       category_name: category.category_name || "",
+      category_description: category.category_description || "",
     }
   );
   return (
@@ -26,6 +27,13 @@ export default function EditCategoryInfoModal({ category, onClose}) {
           name={"category_name"}
           labelText={"Nombre de la Categoría"}
           id={"category_name"}
+        />
+        <FormField
+          onChange={handleChange}
+          value={form.category_description}
+          name={"category_description"}
+          labelText={"Nombre de la Categoría"}
+          id={"category_description"}
         />
       </form>
 

--- a/frontend_web/react+vite/src/modules/categories/components/modals/MoreInfoModal.jsx
+++ b/frontend_web/react+vite/src/modules/categories/components/modals/MoreInfoModal.jsx
@@ -6,6 +6,10 @@ export default function MoreInfoCategoryModal({ category }) {
         {category.category_name}
       </p>
       <p>
+        <strong>Descripción: </strong>
+        {category.category_description}
+      </p>
+      <p>
         <strong>Fecha de Creación: </strong>
         {category.category_date}
       </p>


### PR DESCRIPTION
## Summary

Adds **category description** support in the categories frontend flow: description can be set from **Add** and **Edit** modals and is now shown in **MoreInfoModal** for better detail visibility. Frontend-only, focused change.

## Changes

- **AddCategoryModal**: include `description` field in category creation form flow.
- **EditCategoryInfoModal**: include `description` field for updates.
- **MoreInfoModal**: display category `description` in details view.