### PR TITLE
feat: add credentials support in warranty services and loading state in add modal

### DIFF
--- a/frontend_web/react+vite/src/modules/warranties/components/modals/AddWarrantyModal.jsx
+++ b/frontend_web/react+vite/src/modules/warranties/components/modals/AddWarrantyModal.jsx
@@ -4,6 +4,7 @@ import { useCreateWarranty } from "../../hooks/useCreateWarranties"; // ⚠ Aseg
 
 import SuccessModal from "../../../../globals/components/modals/SuccessModal";
 import ErrorModal from "../../../../globals/components/modals/ErrorModal";
+import Loader from "../../../../globals/components/ui/Loader";
 
 export default function AddWarrantyModal({ onCloseModal, onAddSuccess }) {
   const formRef = useRef(null);
@@ -52,7 +53,7 @@ export default function AddWarrantyModal({ onCloseModal, onAddSuccess }) {
       <ConfirmCancelButtons
         confirmButtonOnClick={handleSubmitViaButton}
         cancelButtonOnClick={onCloseModal}
-        confirmLoading={loading}
+        confirmText={loading ? <Loader /> : "Crear"}
       />
 
       {/* MODALES DE ÉXITO / ERROR */}

--- a/frontend_web/react+vite/src/modules/warranties/services/createWarranty.js
+++ b/frontend_web/react+vite/src/modules/warranties/services/createWarranty.js
@@ -4,6 +4,7 @@ import { getToken } from "../../../utils/auth";
 export async function createWarranty(data) {
   const res = await fetch(`${apiRoutes.apiUrl}${apiRoutes.warranties}/create`, {
     method: "POST",
+    credentials: "include",
     headers: {
       "Content-Type": "application/json",
       Authorization: getToken(),

--- a/frontend_web/react+vite/src/modules/warranties/services/deleteWarranty.js
+++ b/frontend_web/react+vite/src/modules/warranties/services/deleteWarranty.js
@@ -6,6 +6,7 @@ export async function deleteWarranty(warrantyId) {
     `${apiRoutes.apiUrl}${apiRoutes.warranties}/delete/${warrantyId}`,
     {
       method: "DELETE",
+      credentials: "include",
       headers: {
         Authorization: getToken(),
       },

--- a/frontend_web/react+vite/src/modules/warranties/services/updateWarranty.js
+++ b/frontend_web/react+vite/src/modules/warranties/services/updateWarranty.js
@@ -7,6 +7,7 @@ export async function updateWarranty(id, data) {
     `${apiRoutes.apiUrl}${apiRoutes.warranties}/update/${id}`,
     {
       method: "PUT",
+      credentials: "include",
       headers: {
         "Content-Type": "application/json",
         Authorization: getToken(),


### PR DESCRIPTION
## Summary

Enhances the **warranties module** by including **credentials** in all warranty service requests (create, delete, update) for proper cross-origin authentication, and adds a **loading indicator** to the confirm button in `AddWarrantyModal` for better user feedback during submission. Frontend-only.

## Changes

- **Warranty services**: include `credentials` in fetch requests for create, delete, and update operations to support cross-origin authentication.
- **AddWarrantyModal**: add loading state indicator to confirm button for improved UX during warranty creation.
