### PR TITLE
feat: add cross-origin credentials to subcategory services and refactor modal category selection

### DIFF
--- a/frontend_web/react+vite/src/modules/subcategories/components/modals/AddSubcategoryModal.jsx
+++ b/frontend_web/react+vite/src/modules/subcategories/components/modals/AddSubcategoryModal.jsx
@@ -31,15 +31,11 @@ export default function AddSubcategoryModal({ onClose }) {
           name={"category_id"}
           spanText={"Categoria"}
           onChange={handleChange}
-        >
-          <option> Seleccionar </option>
-          {categories.map((category) => (
-            <option value={category.category_id} key={category.category_id}>
-              {category.category_name}
-            </option>
-          ))}
-          <option value="add-subcategory"> Agregar categoria</option>
-        </SelectMenu>
+          options={categories.map((category) => ({
+            value: category.category_id,
+            label: category.category_name,
+          }))}
+        ></SelectMenu>
 
         <FormField
           labelText={"Nombre de la Subcategoria"}

--- a/frontend_web/react+vite/src/modules/subcategories/components/modals/EditSubcategoryModal.jsx
+++ b/frontend_web/react+vite/src/modules/subcategories/components/modals/EditSubcategoryModal.jsx
@@ -19,7 +19,7 @@ export default function EditSubcategoryInfoModal({ subcategory, onClose }) {
     {
       category_id: subcategory.category_id || "",
       subcategory_name: subcategory.subcategory_name || "",
-    }
+    },
   );
   return (
     <section className="flex flex-col items-center">
@@ -31,15 +31,11 @@ export default function EditSubcategoryInfoModal({ subcategory, onClose }) {
           name={"category_id"}
           spanText={"Categoria"}
           onChange={handleChange}
-        >
-          <option> Seleccionar </option>
-          {categories.map((category) => (
-            <option value={category.category_id} key={category.category_id}>
-              {category.category_name}
-            </option>
-          ))}
-          <option value="add-subcategory"> Agregar categoria</option>
-        </SelectMenu>
+          options={categories.map((category) => ({
+            value: category.category_id,
+            label: category.category_name,
+          }))}
+        />
         <FormField
           value={form.subcategory_name}
           onChange={handleChange}

--- a/frontend_web/react+vite/src/modules/subcategories/services/createSubcategorySevice.js
+++ b/frontend_web/react+vite/src/modules/subcategories/services/createSubcategorySevice.js
@@ -4,6 +4,7 @@ import { getToken } from "../../../utils/auth";
 export async function createSubcategory(subcategory_data) {
   const res = await fetch(`${apiRoutes.apiUrl}${apiRoutes.subcategories}/create`, {
     method: "POST",
+    credentials: "include",
     headers: {
       "Content-Type": "application/json",
       Authorization: getToken(),

--- a/frontend_web/react+vite/src/modules/subcategories/services/deleteSubcategoryService.js
+++ b/frontend_web/react+vite/src/modules/subcategories/services/deleteSubcategoryService.js
@@ -4,6 +4,7 @@ import { getToken } from "../../../utils/auth";
 export async function deleteSubcategoryService(subcategory_id) {
     const res = await fetch(`${apiRoutes.apiUrl}${apiRoutes.subcategories}/delete/${subcategory_id}`, {
         method: "DELETE",
+        credentials: "include",
         headers: {
             Authorization: getToken()
         }

--- a/frontend_web/react+vite/src/modules/subcategories/services/editSubcategoryService.js
+++ b/frontend_web/react+vite/src/modules/subcategories/services/editSubcategoryService.js
@@ -6,6 +6,7 @@ export async function editSubcategoryService(subcategory_id, subcategory_data) {
     `${apiRoutes.apiUrl}${apiRoutes.subcategories}/update/${subcategory_id}`,
     {
       method: "PUT",
+      credentials: "include",
       headers: {
         "Content-Type": "application/json",
         Authorization: getToken(),

--- a/frontend_web/react+vite/src/modules/subcategories/services/getCategoriesService.js
+++ b/frontend_web/react+vite/src/modules/subcategories/services/getCategoriesService.js
@@ -6,6 +6,7 @@ export async function getCategories() {
   // Consumimos el endpoint y lo almacenamos en res, le pasamos el metodo y el jwt que necesita para traer los datos
   const res = await fetch(`${apiRoutes.apiUrl}${apiRoutes.categories}/`, {
     method: "GET",
+    credentials: "include",
     headers: {
       Authorization: getToken(),
     },

--- a/frontend_web/react+vite/src/modules/subcategories/services/getSubcategoriesService.js
+++ b/frontend_web/react+vite/src/modules/subcategories/services/getSubcategoriesService.js
@@ -6,6 +6,7 @@ export async function getSubcategories() {
   // Consumimos el endpoint y lo almacenamos en res, le pasamos el metodo y el jwt que necesita para traer los datos
   const res = await fetch(`${apiRoutes.apiUrl}${apiRoutes.subcategories}/`, {
     method: "GET",
+    credentials: "include",
     headers: {
       Authorization: getToken(),
     },


### PR DESCRIPTION
## Summary

Enhances the **subcategories module** by including **credentials** in all subcategory and category API requests (get, create, edit, delete) for proper cross-origin session handling, and refactors **Add/Edit modals** to receive category options via props for cleaner component composition. Frontend-only.

## Changes

- **Subcategory services**: include `credentials` in `getSubcategories`, `createSubcategory`, `editSubcategory`, and `deleteSubcategory` fetch requests for cross-origin support.
- **Category service**: include `credentials` in `getCategories` fetch request for session handling.
- **AddSubcategoryModal**: refactor to use `options` prop for category selection dropdown.
- **EditSubcategoryModal**: refactor to use `options` prop for category selection dropdown.
