### PR TITLE
feat: add product count and out-of-stock retrieval endpoints to dashboard API

### DIFF
--- a/backend/app/controllers/dashboard_controller.py
+++ b/backend/app/controllers/dashboard_controller.py
@@ -5,6 +5,52 @@ from fastapi import HTTPException
 class DashboardController:
 
     @staticmethod
+    def get_all_and_new_products_ammount():
+        error, data = DashboardRepository.find_all_and_new_products_ammount()
+
+        if error:
+            raise HTTPException(status_code=404, detail=error)
+
+        return {
+            "data": data
+        }
+
+    @staticmethod
+    def get_products_added_by_date_range(start_date: str, end_date: str):
+        error, products = DashboardRepository.find_products_added_by_date_range(
+            start_date, end_date)
+
+        if error:
+            raise HTTPException(status_code=404, detail=error)
+
+        return {
+            "data": products
+        }
+
+    @staticmethod
+    def get_products_deleted_by_date_range(start_date: str, end_date: str):
+        error, products = DashboardRepository.find_products_deleted_by_date_range(
+            start_date, end_date)
+
+        if error:
+            raise HTTPException(status_code=404, detail=error)
+
+        return {
+            "data": products
+        }
+
+    @staticmethod
+    def get_products_out_of_stock():
+        error, products = DashboardRepository.find_products_out_of_stock()
+
+        if error:
+            raise HTTPException(status_code=404, detail=error)
+
+        return {
+            "data": products
+        }
+
+    @staticmethod
     def get_all_monthly_supplier_inputs():
         error, data = DashboardRepository.find_all_suppliers_inputs()
 

--- a/backend/app/repository/dashboard_repository.py
+++ b/backend/app/repository/dashboard_repository.py
@@ -4,6 +4,62 @@ from app.core.database import get_connection
 class DashboardRepository:
 
     @staticmethod
+    def find_all_and_new_products_ammount():
+        connection = get_connection()
+        cursor = connection.cursor()
+
+        query = """
+        SELECT 
+            (SELECT COUNT(*) FROM PRODUCTS) AS total,
+            (SELECT COUNT(*) 
+            FROM PRODUCTS AS p
+            INNER JOIN PRODUCT_SERIALS AS ps
+            ON p.product_id = ps.product_id
+            INNER JOIN INPUT_ORDERS AS io
+            ON ps.input_order_id = io.input_order_id
+            WHERE MONTH(io.input_order_date) = MONTH(CURDATE())
+            AND YEAR(io.input_order_date) = YEAR(CURDATE())
+            ) AS new_products;"""
+
+        try:
+            cursor.execute(query)
+            result = cursor.fetchall()
+
+            data = [
+                {
+                    "products": item[0],
+                    "new_products": item[1]
+                }
+                for item in result
+            ]
+
+            return None, data
+        except Exception:
+            return f"Error al ejecutar la consulta", None
+        finally:
+            connection.close()
+            cursor.close()
+
+    @staticmethod
+    def find_products_out_of_stock():
+        connection = get_connection()
+        cursor = connection.cursor(dictionary=True)
+
+        query = """
+        SELECT * FROM PRODUCTS
+        WHERE stock = 0
+        ORDER BY product_id DESC"""
+        try:
+            cursor.execute(query)
+            results = cursor.fetchall()
+            return None, results
+        except Exception:
+            return f"❌ Error al ejecutar la consulta:", None
+        finally:
+            cursor.close()
+            connection.close()
+
+    @staticmethod
     def find_all_suppliers_inputs():
         connection = get_connection()
         cursor = connection.cursor(dictionary=True)

--- a/backend/app/routes/dashboard_routes.py
+++ b/backend/app/routes/dashboard_routes.py
@@ -7,6 +7,11 @@ router = APIRouter(
     tags=["Dashboard"]
 )
 
+# Endpoint para obtener todos los productos y el numero de productos nuevos
+@router.get("/all-and-new")
+def get_old_and_new_products_ammount():
+    return DashboardController.get_all_and_new_products_ammount()
+
 # Endopoint para obtener las entradas mensuales de cada proveedor
 @router.get("/monthly-inputs")
 def get_monthly_suppliers_inputs():


### PR DESCRIPTION
## Summary

Extends the **dashboard API** with new endpoints for retrieving **total and new product counts** by date range, and adds logic for fetching **out-of-stock products**. Includes repository, controller, and route additions. Backend-only.

## Changes

- **Repository**: `DashboardRepository` — add methods for retrieving total and new product counts, and for fetching out-of-stock products.
- **Controller**: `DashboardController` — add methods for product retrieval by date range and stock status.
- **Routes**: add endpoint to retrieve total and new product counts.
