### PR TITLE
refactor: profile hooks/forms with validation and react-query, plus route config cleanup

### DIFF
--- a/frontend_web/react+vite/src/globals/components/modals/profileModal/ChangePasswordModal.jsx
+++ b/frontend_web/react+vite/src/globals/components/modals/profileModal/ChangePasswordModal.jsx
@@ -1,5 +1,5 @@
 // Hooks
-import { useState } from "react";
+import { useInnerModal } from "../../../hooks/useInnerModal";
 import { useUpdateCurrentUserPassword } from "../../../hooks/useUpdateCurrentUserPassword";
 // Components
 import Loader from "../../ui/Loader";
@@ -12,7 +12,7 @@ import SuccessModal from "../SuccessModal";
 import { actionsIcons } from "../../../../assets/icons/actionsIcons";
 
 export default function ChangePasswordModal({ isOpen, onClose, triggerRef }) {
-  const [innerModal, setInnerModal] = useState(null);
+  const { innerType, innerTrigger, openInnerModal } = useInnerModal();
   const {
     handleChange,
     handleSubmit,
@@ -33,7 +33,6 @@ export default function ChangePasswordModal({ isOpen, onClose, triggerRef }) {
       triggerRef={triggerRef}
     >
       <section className="flex flex-col items-center w-full gap-2">
-        <div></div>
         <FormField
           id={"old_password"}
           type={showPasswords.old ? "text" : "password"}
@@ -95,27 +94,29 @@ export default function ChangePasswordModal({ isOpen, onClose, triggerRef }) {
         )}
         <ConfirmCancelButtons
           confirmText={loading ? <Loader /> : "Cambiar"}
-          confirmButtonOnClick={(e) => handleSubmit(e, setInnerModal)}
+          confirmButtonOnClick={(e) => handleSubmit(e, openInnerModal)}
           cancelButtonOnClick={onClose}
           disabled={!passwordsMatch}
         />
-        {innerModal === "success" && (
+        {innerType === "success" && (
           <SuccessModal
+            triggerRef={innerTrigger}
             isOpen={true}
             confirmTitle={"Contraseña actualizada con exito"}
             confirmText={"Su contraseña ha sido actualizada con exito"}
             onClose={onClose}
           />
         )}
-        {innerModal === "error" && (
+        {innerType === "error" && (
           <ErrorModal
+            triggerRef={innerTrigger}
             isOpen={true}
             errorTitle={"No se pudo actualizar su contraseña!"}
             errorText={
               "Verifique que su contraseña anterior sea la correcta y vuelva a intentarlo"
             }
             confirmButtonText={"Volver a intentarlo"}
-            onClose={() => setInnerModal(null)}
+            onClose={() => openInnerModal(null)}
           />
         )}
       </section>

--- a/frontend_web/react+vite/src/globals/components/modals/profileModal/EditInfoModal.jsx
+++ b/frontend_web/react+vite/src/globals/components/modals/profileModal/EditInfoModal.jsx
@@ -1,5 +1,6 @@
 //Hooks
-import { useState } from "react";
+import { useInnerModal } from "../../../hooks/useInnerModal";
+import { useCities } from "../../../../modules/users/hooks/useCities";
 import { useUpdateCurrentUserInfo } from "../../../hooks/useUpdateCurrentUserInfo";
 // Components
 import Loader from "../../ui/Loader";
@@ -9,19 +10,14 @@ import ConfirmCancelButtons from "../ConfirmCancelButtons";
 import Modal from "../Modal";
 import ErrorModal from "../ErrorModal";
 import SuccessModal from "../SuccessModal";
+import SelectMenu from "../SelectMenu";
 
 export default function EditInfoModal({ isOpen, onClose, user, triggerRef }) {
+  const { innerType, innerTrigger, openInnerModal } = useInnerModal();
+  const { cities } = useCities();
   const { handleChange, handleSubmit, userData, loading } =
-    useUpdateCurrentUserInfo({
-      name: user?.name || "",
-      first_surname: user?.first_surname || "",
-      second_surname: user?.second_surname || "",
-      address: user?.address || "",
-      city: user?.city || "",
-      email: user?.email || "",
-      phone: user?.phone || "",
-    });
-  const [innerModal, setInnerModal] = useState(null);
+    useUpdateCurrentUserInfo(user);
+
   return (
     <Modal
       z_index="300"
@@ -41,6 +37,7 @@ export default function EditInfoModal({ isOpen, onClose, user, triggerRef }) {
           onChange={handleChange}
           autoComplete="given-name"
         />
+
         <FormField
           id={"first_surname"}
           name={"first_surname"}
@@ -49,6 +46,7 @@ export default function EditInfoModal({ isOpen, onClose, user, triggerRef }) {
           onChange={handleChange}
           autoComplete="family-name"
         />
+
         <FormField
           id={"second_surname"}
           name={"second_surname"}
@@ -57,6 +55,7 @@ export default function EditInfoModal({ isOpen, onClose, user, triggerRef }) {
           onChange={handleChange}
           autoComplete="family-name"
         />
+
         <FormField
           id={"email"}
           name={"email"}
@@ -65,6 +64,7 @@ export default function EditInfoModal({ isOpen, onClose, user, triggerRef }) {
           onChange={handleChange}
           autoComplete="email"
         />
+
         <FormField
           id={"phone"}
           name={"phone"}
@@ -73,14 +73,20 @@ export default function EditInfoModal({ isOpen, onClose, user, triggerRef }) {
           onChange={handleChange}
           autoComplete="tel"
         />
-        <FormField
+
+        <SelectMenu
           id={"city"}
           name={"city"}
-          labelText={"Ciudad"}
+          spanText={"Ciudad"}
           value={userData.city}
+          options={cities.map((city) => ({
+            value: city.id,
+            label: city.name,
+          }))}
           onChange={handleChange}
           autoComplete="address-level2"
         />
+
         <FormField
           id={"address"}
           name={"address"}
@@ -89,15 +95,17 @@ export default function EditInfoModal({ isOpen, onClose, user, triggerRef }) {
           onChange={handleChange}
           autoComplete="street-address"
         />
+
         <ConfirmCancelButtons
           confirmText={loading ? <Loader /> : "Editar"}
-          confirmButtonOnClick={(e) => handleSubmit(e, setInnerModal)}
+          confirmButtonOnClick={(e) => handleSubmit(e, openInnerModal)}
           cancelButtonOnClick={onClose}
         />
       </section>
       {/* Modales Internas */}
-      {innerModal === "success" && (
+      {innerType === "success" && (
         <SuccessModal
+          triggerRef={innerTrigger}
           isOpen={true}
           confirmTitle={"Información editada con éxito!"}
           confirmText={
@@ -105,18 +113,19 @@ export default function EditInfoModal({ isOpen, onClose, user, triggerRef }) {
           }
           confirmButtonText={"Volver a la pagina"}
           onClose={() => {
-            setInnerModal(null);
-            setTimeout(() => onClose(), 0);
+            openInnerModal(null);
+            onClose();
           }}
         />
       )}
-      {innerModal === "error" && (
+      {innerType === "error" && (
         <ErrorModal
+          triggerRef={innerTrigger}
           isOpen={true}
           errorTitle="¡No se pudo completar el registro!"
           errorText="Verfica que todos los campos esten completos y que el correo electronico es el correcto"
           confirmButtonText="Volver a intentarlo"
-          onClose={() => setInnerModal(null)}
+          onClose={() => openInnerModal(null)}
         />
       )}
     </Modal>

--- a/frontend_web/react+vite/src/globals/components/modals/profileModal/ProfileModal.jsx
+++ b/frontend_web/react+vite/src/globals/components/modals/profileModal/ProfileModal.jsx
@@ -20,7 +20,7 @@ export default function ProfileModal() {
   const [activeSection, setActiveSection] = useState("general");
   const [innerModal, setInnerModal] = useState(null);
 
-  const { user, fetchCurrentUser } = useUser();
+  const { user } = useUser();
 
   return (
     <section
@@ -130,7 +130,6 @@ export default function ProfileModal() {
           triggerRef={editTrigger}
           isOpen={true}
           onClose={() => {
-            fetchCurrentUser();
             setInnerModal(null);
           }}
           user={user}

--- a/frontend_web/react+vite/src/globals/hooks/useUpdateCurrentUserInfo.js
+++ b/frontend_web/react+vite/src/globals/hooks/useUpdateCurrentUserInfo.js
@@ -1,10 +1,22 @@
 import { useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
 import { updateCurrentUserInfoService } from "../services/updateCurrentUserInfoService";
+import { useFormValidation } from "./useFormValidation";
 
-export function useUpdateCurrentUserInfo(user_data) {
-  const [userData, setUserData] = useState(user_data);
+export function useUpdateCurrentUserInfo(user) {
+  const [userData, setUserData] = useState({
+    name: user?.name || "",
+    first_surname: user?.first_surname || "",
+    second_surname: user?.second_surname || "",
+    address: user?.address || "",
+    city: user?.city || "",
+    email: user?.email || "",
+    phone: user?.phone || "",
+  });
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
+  const queryClient = useQueryClient();
+  const { validate, getChanges } = useFormValidation();
 
   function handleChange(e) {
     setUserData((prev) => ({
@@ -13,19 +25,39 @@ export function useUpdateCurrentUserInfo(user_data) {
     }));
   }
 
-  async function handleSubmit(e, setInnerModal) {
+  async function handleSubmit(e, openInnerModal) {
     e.preventDefault();
+
+    const buttonElement = e.currentTarget;
+    const buttonRect = buttonElement.getBoundingClientRect();
+    const triggerData = { currentTarget: buttonElement, rect: buttonRect };
+
+    const isValid = validate(userData);
+
+    if (!isValid) {
+      openInnerModal("error", triggerData);
+      return;
+    }
+
+    const changes = getChanges(user, userData);
+
+    if (Object.keys(changes).length === 0) {
+      openInnerModal("error", triggerData);
+      return;
+    }
+
     setLoading(true);
 
     try {
       const response = await updateCurrentUserInfoService(userData);
       if (response.success) {
-        setInnerModal("success");
+        await queryClient.invalidateQueries({ queryKey: ["currentUser"] });
+        openInnerModal("success", triggerData);
       } else {
-        setInnerModal("error");
+        openInnerModal("error", triggerData);
       }
     } catch (error) {
-      setInnerModal("error");
+      openInnerModal("error", triggerData);
       setError(error);
     } finally {
       setLoading(false);

--- a/frontend_web/react+vite/src/globals/hooks/useUpdateCurrentUserPassword.js
+++ b/frontend_web/react+vite/src/globals/hooks/useUpdateCurrentUserPassword.js
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { updateCurrentUserPasswordService } from "../services/updateCurrentUserPasswordService";
+import { useFormValidation } from "./useFormValidation";
 
 export function useUpdateCurrentUserPassword() {
   const [passwordData, setPasswordData] = useState({
@@ -20,6 +21,7 @@ export function useUpdateCurrentUserPassword() {
   };
   const passwordsMatch =
     passwordData.new_password === passwordData.repeat_password;
+  const { validate } = useFormValidation();
 
   function handleChange(e) {
     setPasswordData((prev) => ({
@@ -28,20 +30,33 @@ export function useUpdateCurrentUserPassword() {
     }));
   }
 
-  async function handleSubmit(e, setInnerModal) {
+  async function handleSubmit(e, openInnerModal) {
     e.preventDefault();
+
     if (!passwordsMatch) return;
+
+    const buttonElement = e.currentTarget;
+    const buttonRect = buttonElement.getBoundingClientRect();
+    const triggerData = { currentTarget: buttonElement, rect: buttonRect };
+
+    const isValid = validate(passwordData);
+
+    if (!isValid) {
+      openInnerModal("error", triggerData);
+      return;
+    }
+
     setLoading(true);
 
     try {
       const response = await updateCurrentUserPasswordService(passwordData);
       if (response.success) {
-        setInnerModal("success");
+        openInnerModal("success");
       } else {
-        setInnerModal("error");
+        openInnerModal("error");
       }
     } catch (error) {
-      setInnerModal("error");
+      openInnerModal("error");
       setError(error);
     } finally {
       setLoading(false);

--- a/frontend_web/react+vite/src/globals/hooks/useUser.js
+++ b/frontend_web/react+vite/src/globals/hooks/useUser.js
@@ -1,26 +1,14 @@
-import { useState, useEffect, useRef } from "react";
+import { useQuery } from "@tanstack/react-query";
 import { getCurrentUserService } from "../services/getCurrentUserService";
 
 export function useUser() {
-  const [user, setUser] = useState([]);
-  const [error, setError] = useState(null);
-  const controllerRef = useRef(null);
+  const user = useQuery({
+    queryKey: ["currentUser"],
+    queryFn: async ({ signal }) => {
+      return getCurrentUserService(signal);
+    },
+    staleTime: 1000 * 60 * 60,
+  });
 
-  async function fetchCurrentUser() {
-    controllerRef.current?.abort();
-    controllerRef.current = new AbortController();
-    try {
-      const data = await getCurrentUserService();
-      setUser(data);
-    } catch (error) {
-      setError(error);
-    }
-  }
-
-  useEffect(() => {
-    fetchCurrentUser();
-    return () => controllerRef.current?.abort();
-  }, []);
-
-  return { user, error, fetchCurrentUser };
+  return { user: user.data || [], error: user.error };
 }

--- a/frontend_web/react+vite/src/router/AppRouter.jsx
+++ b/frontend_web/react+vite/src/router/AppRouter.jsx
@@ -13,7 +13,7 @@ export default function AppRouter() {
       <Route path="/login" element={<Login />} />
 
       {routesConfig.map(({ path, component: Component, roles }) => (
-        <Route element={<ProtectedRoutes roles={roles} />}>
+        <Route key={path} element={<ProtectedRoutes roles={roles} />}>
           <Route path={path} element={<Component />} />
         </Route>
       ))}

--- a/frontend_web/react+vite/src/router/constants/routesConfig.js
+++ b/frontend_web/react+vite/src/router/constants/routesConfig.js
@@ -1,58 +1,63 @@
-import { lazy } from "react";
+import HomePage from "../../modules/home/HomePage";
+import DashBoardPage from "../../modules/dashboard/DashboardPage";
+import UsersPage from "../../modules/users/UsersPage";
+import ProductsPage from "../../modules/products/ProductsPage";
+import CategoriesPage from "../../modules/categories/CategoriesPage";
+import SubcategoriesPage from "../../modules/subcategories/SubcategoriesPage";
+import ReportsPage from "../../modules/reports/ReportsPage";
+import WarrantiesPage from "../../modules/warranties/WarrantiesPage";
+import SuppliersPage from "../../modules/suppliers/SuppliersPage";
+import TransformationsPage from "../../modules/transformations/TransformationsPage";
 
 export const routesConfig = [
   {
     path: "/home",
-    component: lazy(() => import("../../modules/home/HomePage")),
+    component: HomePage,
     roles: ["Admin"],
   },
   {
     path: "/dashboard",
-    component: lazy(() => import("../../modules/dashboard/DashboardPage")),
+    component: DashBoardPage,
     roles: ["Admin"],
   },
   {
     path: "/users",
-    component: lazy(() => import("../../modules/users/UsersPage")),
+    component: UsersPage,
     roles: ["Admin"],
   },
   {
     path: "/products",
-    component: lazy(() => import("../../modules/products/ProductsPage")),
+    component: ProductsPage,
     roles: ["Admin"],
   },
   {
     path: "/categories",
-    component: lazy(() => import("../../modules/categories/CategoriesPage")),
+    component: CategoriesPage,
     roles: ["Admin"],
   },
   {
     path: "/subcategories",
-    component: lazy(
-      () => import("../../modules/subcategories/SubcategoriesPage"),
-    ),
+    component: SubcategoriesPage,
     roles: ["Admin"],
   },
   {
     path: "/reports",
-    component: lazy(() => import("../../modules/reports/ReportsPage")),
+    component: ReportsPage,
     roles: ["Admin"],
   },
   {
     path: "/warranties",
-    component: lazy(() => import("../../modules/warranties/WarrantiesPage")),
+    component: WarrantiesPage,
     roles: ["Admin"],
   },
   {
     path: "/suppliers",
-    component: lazy(() => import("../../modules/suppliers/SuppliersPage")),
+    component: SuppliersPage,
     roles: ["Admin"],
   },
   {
     path: "/transformations",
-    component: lazy(
-      () => import("../../modules/transformations/TransformationsPage"),
-    ),
+    component: TransformationsPage,
     roles: ["Admin"],
   },
 ];


### PR DESCRIPTION
## Summary

Refines the **profile** experience by moving user fetching to **react-query**, adding stronger **form validation** in update hooks, and improving modal state management in profile forms. Also cleans up routing by replacing lazy wrappers in `routesConfig` with direct imports and adding missing `key` props to `AppRouter` route elements.

## Changes

- **Profile data**: `useUser` now relies on **react-query** for fetching/error handling (less local-state boilerplate).
- **Update hooks**:
  - `useUpdateCurrentUserInfo` — validation + query invalidation after updates.
  - `useUpdateCurrentUserPassword` — integrated validation for safer password changes.
- **Profile modals**:
  - `EditInfoModal` — integrates `useInnerModal` and `useCities`.
  - `ChangePasswordModal` — integrates `useInnerModal`.
  - `ProfileModal` — removes extra `fetchCurrentUser` call on close.
- **Routing**:
  - `routesConfig` — replace lazy loading with direct imports for simpler route config.
  - `AppRouter` — add missing `key` on route elements to avoid rendering warnings/issues.