### PR TITLE
fix: align current-user update types and query values handling

### DIFF
--- a/backend/app/models/user_model.py
+++ b/backend/app/models/user_model.py
@@ -32,7 +32,7 @@ class UpdateCurrentUser(BaseModel):
     first_surname: str
     second_surname: str
     address: str
-    city: str
+    city: int
     email: EmailStr
     phone: int
 

--- a/backend/app/repository/user_repository.py
+++ b/backend/app/repository/user_repository.py
@@ -398,7 +398,7 @@ class UserRepository:
                     USER_FIELDS[key]: value for key, value in user_fields.items()}
 
                 columns = ", ".join(f"{col} = %s" for col in mapped.keys())
-                values = list(mapped.values()) + user_id
+                values = list(mapped.values()) + [user_id]
 
                 cursor.execute(
                     f"UPDATE USERS SET {columns} WHERE user_id = %s",
@@ -407,7 +407,7 @@ class UserRepository:
             connection.commit()
 
             return None, True, "Usuario actualizado correctamente"
-        except Exception as e:
+        except Exception:
             connection.rollback()
             return f"Error al ejecutar la consulta", False, None
         finally:


### PR DESCRIPTION
## Summary

Applies two backend fixes in the current-user update flow: corrects the `city` field type in `UpdateCurrentUser` and fixes values-list construction in the user update query to ensure `user_id` is handled correctly during updates.

## Changes

- **Model fix**: `user_model.py` — change `UpdateCurrentUser.city` from `str` to `int` for proper data representation.
- **Repository fix**: `user_repository.py` — correct update-query values construction/order so `user_id` is applied properly.