### PR TITLE
refactor: migrate users hooks to React Query and streamline edit/filter UI

### DIFF
--- a/frontend_web/react+vite/src/modules/users/UsersPage.jsx
+++ b/frontend_web/react+vite/src/modules/users/UsersPage.jsx
@@ -21,7 +21,6 @@ import TopSection from "../../globals/components/ui/TopSection";
 import EnableUserModal from "./components/modals/EnableUserModal";
 
 export default function UsersPage() {
-  // Traer todos los datos o states de sus hooks
   const { modalType, isOpen, modalData, triggerRef, openModal, closeModal } =
     useModal();
   const { users, loading, error, setFilters } = useUsers();

--- a/frontend_web/react+vite/src/modules/users/UsersPage.jsx
+++ b/frontend_web/react+vite/src/modules/users/UsersPage.jsx
@@ -24,7 +24,7 @@ export default function UsersPage() {
   // Traer todos los datos o states de sus hooks
   const { modalType, isOpen, modalData, triggerRef, openModal, closeModal } =
     useModal();
-  const { users, loading, error, fetchUsers } = useUsers();
+  const { users, loading, error, setFilters } = useUsers();
   const [search, setSearch] = useState("");
   const filteredUsers = useSearch(users, search);
 
@@ -39,9 +39,7 @@ export default function UsersPage() {
         sectionName={"Usuarios"}
         addButtonIcon={usersIcons.addUserIcon}
         addButtonText={"Agregar Usuario"}
-        createOnClick={(e) =>
-          openModal(null, "add", fetchUsers, e.currentTarget)
-        }
+        createOnClick={(e) => openModal(null, "add", null, e.currentTarget)}
         filterOnClick={(e) => openModal(null, "filter", null, e.currentTarget)}
       >
         <SearchBar value={search} onChange={setSearch} />
@@ -52,7 +50,6 @@ export default function UsersPage() {
         users={filteredUsers}
         loading={loading}
         error={error}
-        refetch={fetchUsers}
         openModal={openModal}
       />
 
@@ -83,7 +80,7 @@ export default function UsersPage() {
           {modalType === "user" && <ProfileModal />}
           {modalType === "filter" && (
             <FilterUserModal
-              refetch={fetchUsers}
+              setFilters={setFilters}
               onClose={() => closeModal()}
             />
           )}

--- a/frontend_web/react+vite/src/modules/users/components/modals/EditUserInfoModal.jsx
+++ b/frontend_web/react+vite/src/modules/users/components/modals/EditUserInfoModal.jsx
@@ -1,7 +1,8 @@
 // Hooks
-import { useRef, useState } from "react";
 import { useRoles } from "../../hooks/useRoles";
+import { useCities } from "../../hooks/useCities";
 import { useEditUser } from "../../hooks/useEditUser";
+import { useInnerModal } from "../../../../globals/hooks/useInnerModal";
 // Componentes
 import Loader from "../../../../globals/components/ui/Loader";
 import FormField from "../../../../globals/components/ui/FormField";
@@ -10,28 +11,15 @@ import ConfirmCancelButtons from "../../../../globals/components/modals/ConfirmC
 // Modales
 import ErrorModal from "../../../../globals/components/modals/ErrorModal";
 import SuccessModal from "../../../../globals/components/modals/SuccessModal";
-import { useCities } from "../../hooks/useCities";
 
 export default function EditUserInfoModal({ user, onClose }) {
-  const [innerModal, setInnerModal] = useState(null);
-  const containerRef = useRef();
-  const confirmBtnRef = useRef();
+  const { innerType, innerTrigger, openInnerModal } = useInnerModal();
   const { roles } = useRoles();
   const { cities } = useCities();
-  const { handleChange, handleSubmit, loading, form } = useEditUser(user.id, {
-    rol_id: user.rol_id || "",
-    name: user.name || "",
-    first_surname: user.first_surname || "",
-    second_surname: user.second_surname || "",
-    address: user.address || "",
-    city: user.city || "",
-    email: user.email || "",
-    phone: user.phone || "",
-    status: user.status || "",
-  });
+  const { handleChange, handleSubmit, loading, form } = useEditUser(user);
 
   return (
-    <section ref={containerRef} className="flex flex-col items-center">
+    <section className="flex flex-col items-center">
       <form action="" className="w-full flex flex-col gap-2.5">
         <SelectMenu
           name={"rol_id"}
@@ -118,20 +106,16 @@ export default function EditUserInfoModal({ user, onClose }) {
 
       {/* Botones */}
       <ConfirmCancelButtons
-        confirmBtnRef={confirmBtnRef}
         confirmText={loading ? <Loader /> : "Confirmar"}
         cancelText={"Cancelar"}
-        confirmButtonOnClick={(e) => handleSubmit(e, setInnerModal)}
+        confirmButtonOnClick={(e) => handleSubmit(e, openInnerModal)}
         cancelButtonOnClick={onClose}
       />
 
       {/* Modales Internas */}
-      {innerModal === "success" && (
+      {innerType === "success" && (
         <SuccessModal
-          triggerRef={{
-            element: confirmBtnRef.current,
-            rect: null,
-          }}
+          triggerRef={innerTrigger}
           isOpen={true}
           confirmTitle={"Información editada con éxito!"}
           confirmText={
@@ -139,22 +123,19 @@ export default function EditUserInfoModal({ user, onClose }) {
           }
           confirmButtonText={"Volver a la pagina"}
           onClose={() => {
-            setInnerModal(null);
+            openInnerModal(null);
             onClose();
           }}
         />
       )}
-      {innerModal === "error" && (
+      {innerType === "error" && (
         <ErrorModal
-          triggerRef={{
-            element: containerRef.current,
-            rect: null,
-          }}
+          triggerRef={innerTrigger}
           isOpen={true}
           errorTitle="¡No se pudo completar el registro!"
           errorText="Verfica que todos los campos esten completos y que el correo electronico es el correcto"
           confirmButtonText="Volver a intentarlo"
-          onClose={() => setInnerModal(null)}
+          onClose={() => openInnerModal(null)}
         />
       )}
     </section>

--- a/frontend_web/react+vite/src/modules/users/components/modals/FilterUserModal.jsx
+++ b/frontend_web/react+vite/src/modules/users/components/modals/FilterUserModal.jsx
@@ -4,19 +4,10 @@ import SelectMenu from "../../../../globals/components/modals/SelectMenu";
 import FilterModal from "../../../../globals/components/modals/FilterModal";
 import { useCities } from "../../hooks/useCities";
 
-export default function FilterUserModal({ refetch, onClose }) {
+export default function FilterUserModal({ setFilters, onClose }) {
   const { roles } = useRoles();
   const { cities } = useCities();
-  const { form, handleChange, handleApply } = useFilterUsers(
-    {
-      role_order: "",
-      name_order: "",
-      start_date: "",
-      end_date: "",
-      status: "",
-    },
-    refetch,
-  );
+  const { form, handleChange } = useFilterUsers();
 
   return (
     <FilterModal
@@ -26,8 +17,8 @@ export default function FilterUserModal({ refetch, onClose }) {
       orderByFinishDateOnChange={handleChange}
       onClose={onClose}
       applyButtonOnClick={() => {
+        setFilters({ ...form });
         onClose();
-        handleApply();
       }}
     >
       <div className="flex flex-col gap-2">

--- a/frontend_web/react+vite/src/modules/users/components/ui/UserItem.jsx
+++ b/frontend_web/react+vite/src/modules/users/components/ui/UserItem.jsx
@@ -6,7 +6,6 @@ import ActionButtons from "../../../../globals/components/ui/ActionButtons";
 export default function UserItem({
   user,
   openModal,
-  refetch,
   editButtonOnClick,
 }) {
   return (
@@ -55,7 +54,7 @@ export default function UserItem({
           openModal(
             user,
             userStatus[user.status]?.modalType,
-            refetch,
+            null,
             e.currentTarget,
           );
         }}

--- a/frontend_web/react+vite/src/modules/users/components/ui/UsersList.jsx
+++ b/frontend_web/react+vite/src/modules/users/components/ui/UsersList.jsx
@@ -2,7 +2,7 @@ import UserItem from "./UserItem";
 import Skeleton, { SkeletonTheme } from "react-loading-skeleton";
 import "react-loading-skeleton/dist/skeleton.css";
 
-export default function UsersList({ users, loading, refetch, openModal }) {
+export default function UsersList({ users, loading, openModal }) {
   const noUsers = users.length === 0 && !loading;
   const isFirstLoad = users.length === 0 && loading;
 
@@ -28,10 +28,9 @@ export default function UsersList({ users, loading, refetch, openModal }) {
               key={user.id}
               user={user}
               openModal={openModal}
-              refetch={refetch}
               editButtonOnClick={(e) => {
                 e.stopPropagation();
-                openModal(user, "edit", refetch, e.currentTarget);
+                openModal(user, "edit", null, e.currentTarget);
               }}
             />
           ))

--- a/frontend_web/react+vite/src/modules/users/hooks/useCities.js
+++ b/frontend_web/react+vite/src/modules/users/hooks/useCities.js
@@ -1,24 +1,18 @@
-import { useState, useEffect } from "react";
+import { useQuery } from "@tanstack/react-query";
 import { getCitiesService } from "../services/getCitiesService";
 
 export function useCities() {
-  const [cities, setCities] = useState([]);
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState(null);
+  const cities = useQuery({
+    queryKey: ["cities"],
+    queryFn: async ({ signal }) => {
+      return getCitiesService(signal);
+    },
+    staleTime: 1000 * 60 * 5
+  });
 
-  async function fetchCities() {
-    try {
-      const data = await getCitiesService();
-      setCities(data);
-      setLoading(false);
-    } catch (error) {
-      setError(error);
-    }
-  }
-
-  useEffect(() => {
-    fetchCities();
-  }, []);
-
-  return { cities, loading, error, fetchCities };
+  return {
+    cities: cities.data || [],
+    loading: cities.isLoading,
+    error: cities.error,
+  };
 }

--- a/frontend_web/react+vite/src/modules/users/hooks/useDisableUser.js
+++ b/frontend_web/react+vite/src/modules/users/hooks/useDisableUser.js
@@ -1,9 +1,11 @@
 import { useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
 import { disableUserService } from "../services/disableUserService";
 
 export function useDisableUser(userId) {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
+  const queryClient = useQueryClient();
 
   async function handleSubmit(e, closeModal) {
     e.preventDefault();
@@ -11,6 +13,7 @@ export function useDisableUser(userId) {
     try {
       const response = await disableUserService(userId);
       if (response.success) {
+        await queryClient.invalidateQueries({ queryKey: ["users"] });
         closeModal();
       }
     } catch (error) {

--- a/frontend_web/react+vite/src/modules/users/hooks/useEditUser.js
+++ b/frontend_web/react+vite/src/modules/users/hooks/useEditUser.js
@@ -1,11 +1,25 @@
 import { useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
 import { editUserService } from "../services/editUserService";
+import { useFormValidation } from "../../../globals/hooks/useFormValidation";
 
-export function useEditUser(userId, formData) {
-  const [form, setForm] = useState(formData);
+export function useEditUser(user) {
+  const [form, setForm] = useState({
+    rol_id: user.rol_id || "",
+    name: user.name || "",
+    first_surname: user.first_surname || "",
+    second_surname: user.second_surname || "",
+    address: user.address || "",
+    city: user.city || "",
+    email: user.email || "",
+    phone: user.phone || "",
+    status: user.status || "",
+  });
   const [data, setData] = useState([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
+  const queryClient = useQueryClient();
+  const { validate, getChanges } = useFormValidation();
 
   function handleChange(e) {
     setForm((prev) => ({
@@ -14,21 +28,40 @@ export function useEditUser(userId, formData) {
     }));
   }
 
-  async function handleSubmit(e, setInnerModal) {
+  async function handleSubmit(e, openInnerModal) {
     e.preventDefault();
+
+    const buttonElement = e.currentTarget;
+    const buttonRect = buttonElement.getBoundingClientRect();
+    const triggerData = { currentTarget: buttonElement, rect: buttonRect };
+
+    const isValid = validate(form);
+
+    if (!isValid) {
+      openInnerModal("error", triggerData);
+      return;
+    }
+
+    const changes = getChanges(user, form);
+
+    if (Object.keys(changes).length === 0) {
+      openInnerModal("error", triggerData);
+      return;
+    }
 
     setLoading(true);
 
     try {
-      const response = await editUserService(userId, form);
+      const response = await editUserService(user.id, form);
       if (response.success) {
-        setInnerModal("success");
+        queryClient.invalidateQueries({ queryKey: ["users"] });
+        openInnerModal("success", triggerData);
       } else {
-        setInnerModal("error");
+        openInnerModal("error", triggerData);
       }
       setData(response);
     } catch (error) {
-      setInnerModal("error");
+      openInnerModal("error", triggerData);
       setError(error);
     } finally {
       setLoading(false);

--- a/frontend_web/react+vite/src/modules/users/hooks/useEnableUser.js
+++ b/frontend_web/react+vite/src/modules/users/hooks/useEnableUser.js
@@ -1,9 +1,11 @@
 import { useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
 import { enableUserService } from "../services/enableUserService";
 
 export function useEnableUser(userId) {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
+  const queryClient = useQueryClient();
 
   async function handleSubmit(e, closeModal) {
     e.preventDefault();
@@ -11,6 +13,7 @@ export function useEnableUser(userId) {
     try {
       const response = await enableUserService(userId);
       if (response.success) {
+        await queryClient.invalidateQueries({ queryKey: ["users"] });
         closeModal();
       }
     } catch (error) {

--- a/frontend_web/react+vite/src/modules/users/hooks/useFilterUsers.js
+++ b/frontend_web/react+vite/src/modules/users/hooks/useFilterUsers.js
@@ -1,7 +1,13 @@
 import { useState } from "react";
 
-export function useFilterUsers(filters, refetch) {
-  const [form, setForm] = useState(filters);
+export function useFilterUsers() {
+  const [form, setForm] = useState({
+    role_order: "",
+    name_order: "",
+    start_date: "",
+    end_date: "",
+    status: "",
+  });
 
   function handleChange(e) {
     setForm((prev) => ({
@@ -10,13 +16,8 @@ export function useFilterUsers(filters, refetch) {
     }));
   }
 
-  function handleApply() {
-    refetch(form);
-  }
-
   return {
     form,
     handleChange,
-    handleApply,
   };
 }

--- a/frontend_web/react+vite/src/modules/users/hooks/useRoles.js
+++ b/frontend_web/react+vite/src/modules/users/hooks/useRoles.js
@@ -1,24 +1,18 @@
-import { useState, useEffect } from "react";
+import { useQuery } from "@tanstack/react-query";
 import { getRoles } from "../services/getRolesService";
 
 export function useRoles() {
-  const [roles, setRoles] = useState([]);
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState(null);
+  const roles = useQuery({
+    queryKey: ["roles"],
+    queryFn: async ({ signal }) => {
+      return getRoles(signal);
+    },
+    staleTime: 1000 * 60 * 30
+  });
 
-  useEffect(() => {
-    async function fetchRoles() {
-      try {
-        const data = await getRoles();
-        setRoles(data);
-        setLoading(false);
-      } catch (error) {
-        setError(error);
-      }
-    }
-
-    fetchRoles();
-  }, []);
-
-  return { roles, loading, error };
+  return {
+    roles: roles.data || [],
+    loading: roles.isLoading,
+    error: roles.error,
+  };
 }

--- a/frontend_web/react+vite/src/modules/users/hooks/useUsers.js
+++ b/frontend_web/react+vite/src/modules/users/hooks/useUsers.js
@@ -1,39 +1,22 @@
-import { useEffect, useRef, useState } from "react";
+import { useState } from "react";
 import { getUsers } from "../services/getUsersService";
+import { useQuery } from "@tanstack/react-query";
 
 export function useUsers() {
-  const [users, setUsers] = useState([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState(null);
-  const controllerRef = useRef(null);
+  const [filters, setFilters] = useState({});
 
-  // Esta functión llama al service getAllUsers y espera a obtener todos los datos y los almacena en "data"
-  async function fetchUsers(form) {
-    controllerRef.current?.abort();
-    controllerRef.current = new AbortController();
-
-    setLoading(true);
-    try {
-      const data = await getUsers(controllerRef.current.signal, form);
-      setUsers(data);
-      setLoading(false);
-    } catch (error) {
-      if (error.name === "AbortError") return;
-      setError(error.message);
-    } finally {
-      setLoading(false);
-    }
-  }
-
-  useEffect(() => {
-    fetchUsers();
-    return () => controllerRef.current?.abort();
-  }, []);
+  const users = useQuery({
+    queryKey: ["users"],
+    queryFn: async ({ signal }) => {
+      return getUsers(signal, filters);
+    },
+    staleTime: 1000 * 60 * 30,
+  });
 
   return {
-    users,
-    loading,
-    error,
-    fetchUsers,
+    users: users.data || [],
+    loading: users.isLoading,
+    error: users.error,
+    setFilters,
   };
 }


### PR DESCRIPTION
## Summary

Refactors the **Users** frontend around **TanStack React Query**: **`useUsers`**, **`useRoles`**, and **`useCities`** no longer manage ad-hoc fetch state; **`useEnableUser`** / **`useDisableUser`** invalidate user queries after mutations. **`useFilterUsers`** is simplified (defaults in hook state, fewer parameters). **`UsersPage`** drives filtering via **`setFilters`** instead of imperative **`fetchUsers`** for modal actions. **`EditUserInfoModal`** leans on **`useInnerModal`** for inner state; **`useEditUser`** gains clearer validation and state handling. Removes unused **`refetch`** threading through **`UsersList`**, **`UserItem`**, and **`FilterUserModal`**.

## Changes

- **Data fetching**: `useUsers.js`, `useRoles.js`, `useCities.js` — React Query–based loading/error/cache behavior.
- **Mutations**: `useEnableUser.js`, `useDisableUser.js` — invalidate relevant queries after enable/disable.
- **Filtering**: `useFilterUsers.js` — simplified hook API; `FilterUserModal.jsx` — aligned with new hook; `UsersPage.jsx` — filter updates via `setFilters`.
- **Edit flow**: `EditUserInfoModal.jsx` — `useInnerModal` + leaner props; `useEditUser.js` — validation and state improvements.
- **List UI**: `UsersList.jsx`, `UserItem.jsx` — drop unused `refetch` prop chain.
- **Cleanup**: `UsersPage.jsx` — remove commented code.