### PR TITLE
refactor: improve users hooks and AddUserModal with React Query

### DIFF
--- a/frontend_web/react+vite/src/modules/users/components/modals/AddUserModal.jsx
+++ b/frontend_web/react+vite/src/modules/users/components/modals/AddUserModal.jsx
@@ -1,5 +1,4 @@
 // Hooks
-import { useState, useRef } from "react";
 import { useRoles } from "../../hooks/useRoles";
 import { useCities } from "../../hooks/useCities";
 import { useCreateUser } from "../../hooks/useCreateUser";
@@ -11,13 +10,12 @@ import ConfirmCancelButtons from "../../../../globals/components/modals/ConfirmC
 // Modales
 import ErrorModal from "../../../../globals/components/modals/ErrorModal";
 import SuccessModal from "../../../../globals/components/modals/SuccessModal";
+import { useInnerModal } from "../../../../globals/hooks/useInnerModal";
 
 export default function AddUserModal({ onClose }) {
-  // Estado para las modales se abren encima de esta
-  const [innerModal, setInnerModal] = useState(null);
+  const { innerType, innerTrigger, openInnerModal } = useInnerModal();
   const { roles } = useRoles();
   const { cities } = useCities();
-  const containerRef = useRef(null);
   const { form, loading, handleSubmit, handleChange } = useCreateUser({
     rol_id: "",
     name: "",
@@ -30,7 +28,7 @@ export default function AddUserModal({ onClose }) {
   });
 
   return (
-    <section ref={containerRef} className="flex flex-col items-center">
+    <section className="flex flex-col items-center">
       {/* Formulario para la informacion del nuevo usuario */}
       <form action="" className="w-full flex flex-col gap-2.5">
         {/* Menú de roles */}
@@ -119,17 +117,14 @@ export default function AddUserModal({ onClose }) {
       <ConfirmCancelButtons
         confirmText={loading ? <Loader /> : "Crear"}
         cancelText={"Cancelar"}
-        confirmButtonOnClick={(e) => handleSubmit(e, setInnerModal)}
+        confirmButtonOnClick={(e) => handleSubmit(e, openInnerModal)}
         cancelButtonOnClick={onClose}
       />
 
       {/* Modales Internas */}
-      {innerModal === "success" && (
+      {innerType === "success" && (
         <SuccessModal
-          triggerRef={{
-            element: containerRef.current,
-            rect: null,
-          }}
+          triggerRef={innerTrigger}
           isOpen={true}
           confirmTitle={"Usuario creado con éxito!"}
           confirmText={
@@ -138,21 +133,18 @@ export default function AddUserModal({ onClose }) {
           confirmButtonText={"Volver a la pagina"}
           onClose={() => {
             onClose();
-            setInnerModal(null);
+            openInnerModal(null);
           }}
         />
       )}
-      {innerModal === "error" && (
+      {innerType === "error" && (
         <ErrorModal
-          triggerRef={{
-            element: containerRef.current,
-            rect: null,
-          }}
+          triggerRef={innerTrigger}
           isOpen={true}
           errorTitle="No se puedo completar el registro!"
           errorText="Verfica que todos los campos esten completos y que el correo electronico no este registrado"
           confirmButtonText="Volver a intentarlo"
-          onClose={() => setInnerModal(null)}
+          onClose={() => openInnerModal(null)}
         />
       )}
     </section>

--- a/frontend_web/react+vite/src/modules/users/hooks/useCreateUser.js
+++ b/frontend_web/react+vite/src/modules/users/hooks/useCreateUser.js
@@ -1,10 +1,12 @@
 import { useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
 import { createUser } from "../services/createUserService";
 
 export function useCreateUser(formData) {
   const [form, setForm] = useState(formData);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
+  const queryClient = useQueryClient();
 
   function handleChange(e) {
     setForm((prev) => ({
@@ -14,23 +16,28 @@ export function useCreateUser(formData) {
   }
 
   // Función que pasa los parametros al service y valida la respuesta
-  async function handleSubmit(e, setInnerModal) {
+  async function handleSubmit(e, openInnerModal) {
     e.preventDefault();
+
+    const buttonElement = e.currentTarget;
+    const buttonRect = buttonElement.getBoundingClientRect();
+    const triggerData = { currentTarget: buttonElement, rect: buttonRect };
 
     setLoading(true);
 
     try {
       const response = await createUser(form);
       if (response.success) {
-        setInnerModal("success");
+        queryClient.invalidateQueries({ queryKey: ["users"] });
+        openInnerModal("success", triggerData);
       }
     } catch (error) {
-      setInnerModal("error");
+      openInnerModal("error", triggerData);
       setError(error);
     } finally {
       setLoading(false);
     }
   }
 
-  return { form, loading, handleSubmit, handleChange };
+  return { form, loading, error, handleSubmit, handleChange };
 }

--- a/frontend_web/react+vite/src/modules/users/hooks/useUsers.js
+++ b/frontend_web/react+vite/src/modules/users/hooks/useUsers.js
@@ -3,14 +3,14 @@ import { getUsers } from "../services/getUsersService";
 import { useQuery } from "@tanstack/react-query";
 
 export function useUsers() {
-  const [filters, setFilters] = useState({});
+  const [filters, setFilters] = useState();
 
   const users = useQuery({
-    queryKey: ["users"],
+    queryKey: ["users", filters],
     queryFn: async ({ signal }) => {
       return getUsers(signal, filters);
     },
-    staleTime: 1000 * 60 * 30,
+    staleTime: 1000 * 60 * 10,
   });
 
   return {


### PR DESCRIPTION
## Summary

Refactors the **Users** frontend data layer and create UX: **`useCreateUser`** now leans on **React Query** for cache updates and clearer modal handling; **`useUsers`** includes **filters in the query key** and a **lower stale time** so lists stay in sync with filter changes. **`AddUserModal`** is simplified by using **`useInnerModal`** for nested modal state. Frontend-only.

## Changes

- **`useCreateUser.js`**: React Query integration for user list/cache behavior after create; improved modal flow.
- **`useUsers.js`**: query key reflects **filters**; **stale time** adjusted to reduce stale reads when filters change.
- **`AddUserModal.jsx`**: internal modals managed via **`useInnerModal`** (less local state boilerplate).