### PR TITLE
feat: add product_details_id support in product update flow and fix mapping/types

### DIFF
--- a/backend/app/models/product_details_model.py
+++ b/backend/app/models/product_details_model.py
@@ -9,4 +9,4 @@ class ProductDetails(BaseModel):
 
 class UpdateProductDetails(BaseModel):
     model: int
-    product_details_id: str
+    product_details_id: int

--- a/backend/app/models/product_model.py
+++ b/backend/app/models/product_model.py
@@ -13,6 +13,7 @@ class Product(BaseModel):
 
 class UpdateProduct(BaseModel):
     id: int
+    product_details_id: int
     input_order: Optional[int] = None
     subcategory: Optional[int] = None
     serial: Optional[str] = None

--- a/backend/app/repository/products_repository.py
+++ b/backend/app/repository/products_repository.py
@@ -51,6 +51,7 @@ class ProductsRepository:
             pb.product_brand_id,
             pb.product_brand_name,
             ps.product_garanty_input,
+            pd.product_details_id,
             p.product_status
             FROM SUPPLIERS AS s
             INNER JOIN INPUT_ORDERS AS io
@@ -136,7 +137,8 @@ class ProductsRepository:
                     "brand_id": item[12],
                     "brand": item[13],
                     "warranty_time": item[14],
-                    "status": item[15]
+                    "status": item[15],
+                    "product_details_id": item[16]
                 }
                 for item in result
             ]
@@ -257,7 +259,8 @@ class ProductsRepository:
                 if key in data
             }:
                 error, success, message = ProductDetailsRepository.update_product_details(
-                    UpdateProductDetails(**details_fields), cursor
+                    UpdateProductDetails(
+                        product_details_id=data["product_details_id"], **details_fields), cursor
                 )
                 if error is not None or not success:
                     return error, success, message

--- a/backend/app/repository/products_repository.py
+++ b/backend/app/repository/products_repository.py
@@ -51,7 +51,7 @@ class ProductsRepository:
             pb.product_brand_id,
             pb.product_brand_name,
             ps.product_garanty_input,
-            pd.product_details_id,
+            p.product_details_id,
             p.product_status
             FROM SUPPLIERS AS s
             INNER JOIN INPUT_ORDERS AS io
@@ -137,8 +137,8 @@ class ProductsRepository:
                     "brand_id": item[12],
                     "brand": item[13],
                     "warranty_time": item[14],
-                    "status": item[15],
-                    "product_details_id": item[16]
+                    "product_details_id": item[15],
+                    "status": item[16]
                 }
                 for item in result
             ]
@@ -273,7 +273,9 @@ class ProductsRepository:
             }:
                 error, success, message = ProductSerialsRepository.update_product_serial(
                     UpdateProductSerial(
-                        id=data["id"], **serial_fields), cursor
+                        id=data["id"],
+                        **serial_fields
+                    ), cursor
                 )
                 if error is not None or not success:
                     return error, success, message


### PR DESCRIPTION
## Summary

Adds `product_details_id` to the product update flow and aligns type/mapping behavior across models and repository logic. This includes updating update models, wiring `product_details_id` in product retrieval/update paths, changing `UpdateProductDetails.product_details_id` to `int`, and fixing repository indexing for `product_details_id` and status.

## Changes

- **Models**
  - `product_model.py`: add `product_details_id` to `UpdateProduct`.
  - `product_details_model.py`: change `UpdateProductDetails.product_details_id` type from `str` to `int`.
- **Repository**
  - `products_repository.py`: include `product_details_id` in retrieval/update logic and fix indexing for `product_details_id` and status mapping.
