### PR TITLE
refactor: normalize product form fields and brand filtering in products modals

### DIFF
--- a/frontend_web/react+vite/src/modules/products/components/modals/AddProductModal.jsx
+++ b/frontend_web/react+vite/src/modules/products/components/modals/AddProductModal.jsx
@@ -29,10 +29,10 @@ export default function AddProductModal({ onCloseModal }) {
     <section className="w-full flex flex-col items-center gap-2">
       {/* Menú de ordenes de entrada */}
       <SelectMenu
-        value={form.input_order_id}
+        value={form.input_order}
         spanText={"Orden de entrada"}
         onChange={handleChange}
-        name={"input_order_id"}
+        name={"input_order"}
         addIconFunction={(e) => openInnerModal("addInputOrder", e)}
         addButtonInvisible={false}
         options={inputOrders.map((inputOrder) => ({
@@ -43,8 +43,8 @@ export default function AddProductModal({ onCloseModal }) {
 
       {/* Menú de subcategorias */}
       <SelectMenu
-        value={form.subcategory_id}
-        name={"subcategory_id"}
+        value={form.subcategory}
+        name={"subcategory"}
         spanText={"Subcategoria"}
         onChange={handleChange}
         addIconFunction={(e) => openInnerModal("addSubcategory", e)}
@@ -57,17 +57,17 @@ export default function AddProductModal({ onCloseModal }) {
 
       {/* Menú de marcas */}
       <SelectMenu
-        value={form.product_brand_id}
+        value={form.brand}
         spanText={"Marca"}
-        name={"product_brand_id"}
+        name={"brand"}
         onChange={handleChange}
         addIconFunction={(e) => openInnerModal("addBrand", e)}
         addButtonInvisible={false}
         options={brands
           .filter(
             (brand) =>
-              !form.subcategory_id ||
-              brand.subcategory_id === form.subcategory_id,
+              !form.subcategory ||
+              brand.subcategories.split(",").includes(String(form.subcategory)),
           )
           .map((brand) => ({
             value: brand.id,
@@ -77,25 +77,22 @@ export default function AddProductModal({ onCloseModal }) {
 
       {/* Menú de modelos */}
       <SelectMenu
-        value={form.product_details_id}
+        value={form.model}
         spanText={"Modelo"}
-        name={"product_details_id"}
+        name={"model"}
         onChange={handleChange}
         id={"model"}
         addIconFunction={(e) => openInnerModal("addModel", e)}
         addButtonInvisible={false}
         options={models
-          .filter(
-            (model) =>
-              !form.product_brand_id || model.brand === form.product_brand_id,
-          )
+          .filter((model) => !form.brand || model.brand === form.brand)
           .map((model) => ({
             value: model.id,
             label: model.model,
           }))}
       />
       <FormField
-        name={"product_serial"}
+        name={"serial"}
         labelText={"Serial"}
         placeholder={"10KQ340"}
         id={"product_serial"}
@@ -103,9 +100,9 @@ export default function AddProductModal({ onCloseModal }) {
       />
 
       <SelectMenu
-        name={"product_garanty_input"}
+        name={"warranty_time"}
         onChange={handleChange}
-        value={form.product_garanty_input}
+        value={form.warranty_time}
         spanText={"Tiempo de garantía"}
         options={[
           { value: "3", label: "3 Meses" },

--- a/frontend_web/react+vite/src/modules/products/components/modals/ProductsFilterModal.jsx
+++ b/frontend_web/react+vite/src/modules/products/components/modals/ProductsFilterModal.jsx
@@ -77,7 +77,9 @@ export default function ProductsFilterModal({ setFilters, onCloseModal }) {
             .filter(
               (brand) =>
                 !form.subcategory_order ||
-                brand.subcategory_id === form.subcategory_order,
+                brand.subcategories
+                  .split(",")
+                  .includes(String(form.subcategory_order)),
             )
             .map((brand) => ({
               value: brand.id,

--- a/frontend_web/react+vite/src/modules/products/hooks/useCreateProduct.js
+++ b/frontend_web/react+vite/src/modules/products/hooks/useCreateProduct.js
@@ -1,19 +1,21 @@
 import { useState } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import { createProductService } from "../services/createProductService";
+import { useFormValidation } from "../../../globals/hooks/useFormValidation";
 
 export function useCreateProduct() {
   const queryClient = useQueryClient();
   const [form, setForm] = useState({
-    input_order_id: "",
-    subcategory_id: "",
-    product_details_id: "",
-    product_serial: "",
-    product_brand_id: "",
-    product_garanty_input: "",
+    input_order: "",
+    subcategory: "",
+    model: "",
+    serial: "",
+    brand: "",
+    warranty_time: "",
   });
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
+  const { validate } = useFormValidation();
 
   function handleChange(e) {
     setForm((prev) => ({
@@ -27,17 +29,12 @@ export function useCreateProduct() {
 
     const buttonElement = e.currentTarget;
     const buttonRect = buttonElement.getBoundingClientRect();
+    const triggerData = { currentTarget: buttonElement, rect: buttonRect };
 
-    const requiredFields = Object.keys(form);
-    const isFormIncomplete = requiredFields.some(
-      (field) => !form[field] || form[field].toString().trim() === "",
-    );
+    const isValid = validate(form);
 
-    if (isFormIncomplete) {
-      openInnerModal("error", {
-        currentTarget: buttonElement,
-        rect: buttonRect,
-      });
+    if (!isValid) {
+      openInnerModal("error", triggerData);
       return;
     }
 
@@ -46,17 +43,11 @@ export function useCreateProduct() {
     try {
       const response = await createProductService(form);
       if (response.sucess) {
-        openInnerModal("success", {
-          currentTarget: buttonElement,
-          rect: buttonRect,
-        });
+        openInnerModal("success", triggerData);
         await queryClient.invalidateQueries({ queryKey: ["products"] });
       }
     } catch (error) {
-      openInnerModal("error", {
-        currentTarget: buttonElement,
-        rect: buttonRect,
-      });
+      openInnerModal("error", triggerData);
       setError(error);
     } finally {
       setLoading(false);

--- a/frontend_web/react+vite/src/modules/products/hooks/useEditProduct.js
+++ b/frontend_web/react+vite/src/modules/products/hooks/useEditProduct.js
@@ -13,8 +13,9 @@ export function useEditProduct(product) {
     subcategory: product.subcategory_id || "",
     serial: product.product_serial || "",
     brand: product.brand_id || "",
-    model: product.product_details_id || "",
+    model: product.model_id || "",
     warranty_time: product.warranty_time || "",
+    product_details_id: product.product_details_id,
     status: product.status || "",
   });
   const [loading, setLoading] = useState(false);
@@ -53,6 +54,7 @@ export function useEditProduct(product) {
     try {
       const response = await editProductService({
         id: product.product_id,
+        product_details_id: product.product_details_id,
         ...changes,
       });
       if (response.success) {


### PR DESCRIPTION
## Summary

Refactors the products module to standardize form field naming across create/edit flows, align product model usage (including `product_details_id` during edit), and correct brand filtering behavior in `ProductsFilterModal` when subcategory IDs are involved. Also streamlines hook/form integration for cleaner validation handling.

## Changes

- **Forms / modals**: `AddProductModal.jsx` field names updated for consistency and clearer mapping.
- **Filtering**: `ProductsFilterModal.jsx` brand filter logic adjusted to correctly handle subcategory ID scenarios.
- **Hooks**: `useCreateProduct.js` refactored to align with updated form field names and validation flow.
- **Edit flow**: `useEditProduct.js` updated to include `product_details_id` and match normalized field mapping.